### PR TITLE
Update README.md - enhancement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ styles: |
 More information here :
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_operator
 
-For now you have access to these variables in some cards (not all):
+For now, you have access to these variables in some cards (not all):
 
  `state` will return the state of your defined `entity`.  
  `entity` will return your entity you defined like `switch.test` in this example.


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Styles template**"

"**For now you have access**"  should be "**For now, you have access**"


Screenshot-

![Screenshot (109)](https://github.com/Clooos/Bubble-Card/assets/114826902/3b359d32-729b-4bd8-a81e-160c8c3ab019)
