### PR TITLE
Hide popup related vertical cards sooner

### DIFF
--- a/src/cards/pop-up.ts
+++ b/src/cards/pop-up.ts
@@ -34,6 +34,16 @@ export function handlePopUp(context) {
         return;
     }
 
+    if (context.errorTriggered) {
+        return;
+    }
+
+    if (!context.initStyleAdded && !context.popUp && !editor) {
+        // Hide vertical stack content before initialization
+        context.card.style.marginTop = '4000px';
+        context.initStyleAdded = true;
+    }
+
     let {
         customStyles,
         entityId,
@@ -83,16 +93,6 @@ export function handlePopUp(context) {
     let lastTouchY;
     let closeTimeout;
     let rgbaBgColor;
-
-    if (context.errorTriggered) {
-        return;
-    }
-
-    if (!context.initStyleAdded && !context.popUp && !editor) {
-        // Hide vertical stack content before initialization
-        context.card.style.marginTop = '4000px';
-        context.initStyleAdded = true;
-    }
 
     function removeHash() {
 	    history.replaceState(null, null, location.href.split('#')[0]);


### PR DESCRIPTION
Fixes #370

`getVariables` takes a little bit of time, likely due to DOM manipulations.

Move initial hiding popup logic sooner than reading config

## Before fix:

<details>
  <summary>Broken Preview (Epilepsy warning)</summary>

  ![bubble visible all cards](https://github.com/Clooos/Bubble-Card/assets/13166802/ad972253-9156-4099-bd29-401f13d263c9)

</details>

## After fix:

<details>
  <summary>Fixed Preview (Epilepsy warning)</summary>

  ![bubble fixed visible all cards](https://github.com/Clooos/Bubble-Card/assets/13166802/2b4591bc-095a-4bb6-a07a-ff759486d945)

</details>
