### PR TITLE
Fix: can click through backdrop

### DIFF
--- a/src/cards/pop-up.ts
+++ b/src/cards/pop-up.ts
@@ -368,7 +368,7 @@ export function handlePopUp(context) {
 				opacity: 1;
 				backdrop-filter: blur(16px);
 				-webkit-backdrop-filter: blur(16px);
-                                pointer-events: all;
+                                pointer-events: auto;
 		    }
 
 		    .backdrop.hidden {

--- a/src/cards/pop-up.ts
+++ b/src/cards/pop-up.ts
@@ -368,6 +368,7 @@ export function handlePopUp(context) {
 				opacity: 1;
 				backdrop-filter: blur(16px);
 				-webkit-backdrop-filter: blur(16px);
+                                pointer-events: all;
 		    }
 
 		    .backdrop.hidden {


### PR DESCRIPTION
Cause of `pointer-events: none` you can click _through_ the backdrop and trigger underlying / hidden elements: 

![Screenshot_20240214_220245](https://github.com/Clooos/Bubble-Card/assets/1191572/55d53e26-7023-43c4-9528-3105dbdbc92e)
