### PR TITLE
fix: mobile drag open execute the actions

### DIFF
--- a/src/cards/button.ts
+++ b/src/cards/button.ts
@@ -210,16 +210,16 @@ export function handleButton(context) {
                 toggleEntity(hass, entityId);
             }
         }, { passive: true });
-        addActions(iconContainer, context.config, hass, forwardHaptic);
+        addActions(iconContainer, context.config);
         context.eventAdded = true;
     } else if (!context.eventAdded && buttonType === 'slider') {
         rangeSlider.addEventListener('mousedown', handleStart, { passive: true });
         rangeSlider.addEventListener('touchstart', handleStart, { passive: true });
-        addActions(iconContainer, context.config, hass, forwardHaptic);
+        addActions(iconContainer, context.config);
         context.eventAdded = true;
     } else if (!context.eventAdded && buttonType === 'custom') {
         switchButton.addEventListener('click', () => tapFeedback(context.switchButton), { passive: true });
-        addActions(switchButton, context.config, hass, forwardHaptic);
+        addActions(switchButton, context.config);
         context.eventAdded = true;
     }
 

--- a/src/cards/cover.ts
+++ b/src/cards/cover.ts
@@ -99,7 +99,7 @@ export function handleCover(context) {
         }, { passive: true });
         
         context.iconContainer = context.content.querySelector('.icon-container');
-        addActions(context.iconContainer, config, hass, forwardHaptic);
+        addActions(context.iconContainer, config);
 
         context.coverAdded = true;
     }

--- a/src/cards/horizontal-buttons-stack.ts
+++ b/src/cards/horizontal-buttons-stack.ts
@@ -11,7 +11,6 @@ import {
     forwardHaptic,
     navigate
 } from '../tools/utils.ts';
-import { addActions } from '../tools/tap-actions.ts';
 import { getVariables } from '../var/cards.ts';
 
 let editor;

--- a/src/cards/pop-up.ts
+++ b/src/cards/pop-up.ts
@@ -154,7 +154,7 @@ export function handlePopUp(context) {
 	        context.div.appendChild(context.iconContainer);
 
 	        createIcon(context, entityId, icon, context.iconContainer, editor);
-	        addActions(context.iconContainer, config, hass, forwardHaptic);
+	        addActions(context.iconContainer, config);
 
 	        context.h2 = document.createElement("h2");
 	        context.h2.textContent = name;


### PR DESCRIPTION
Here is another PR to fix a bug I encounter:
I am on mobile an I try to scroll my page. If my scroll starts on a bubble-card, it execute the action even if my drag ends on another element (not really sure which one -probably hold-). This is caused by the mouse events behavior which is a bit different than the mouse ones.

To solve this, I used the pointer events, that should be compatible anywhere (I don't have an iPhone, so I can't be sure it's working fine on iPhone, but desktop and Android are OK).

I also change a bit how `ActionHandler` works: this allows to reduce the amount of timeout executed in the page.

Finally, some arguments were not used so I removed them.