### PR TITLE
Use built in HomeAssistant's built in `editMode`

### DIFF
--- a/src/bubble-card.ts
+++ b/src/bubble-card.ts
@@ -1,6 +1,6 @@
 import { version } from './var/version.ts';
 import { addUrlListener } from './tools/url-listener.ts';
-import { initializeContent, checkEditor, checkResources } from './tools/init.ts';
+import { initializeContent } from './tools/init.ts';
 import { handlePopUp } from './cards/pop-up.ts';
 import { handleHorizontalButtonsStack } from './cards/horizontal-buttons-stack.ts';
 import { handleButton } from './cards/button.ts';
@@ -9,9 +9,8 @@ import { handleCover } from './cards/cover.ts';
 import { handleEmptyColumn } from './cards/empty-column.ts';
 import BubbleCardEditor from './editor/bubble-card-editor.ts';
 
-let editor;
-
 class BubbleCard extends HTMLElement {
+    editor = false;
 
     connectedCallback() {
         window.addEventListener('focus', this.updateOnFocus);
@@ -27,15 +26,27 @@ class BubbleCard extends HTMLElement {
         this.hass = this._hass;
     }
 
+    set editMode(editMode) {
+        this.editor = editMode;
+
+        if (this._hass)
+            this.updateBubbleCard();
+    }
+
     set hass(hass) {
 
         initializeContent(this);
 
         this._hass = hass;
 
-        editor = checkEditor();
-        this.editor = editor;
+        this.updateBubbleCard();
 
+        if (!window.columnFix) {
+            window.columnFix = this.config.column_fix
+        }
+    }
+
+    updateBubbleCard() {
         switch (this.config.card_type) {
 
             // Initialize pop-up card
@@ -47,30 +58,26 @@ class BubbleCard extends HTMLElement {
             case 'button' :
                 handleButton(this);
                 break;
-    
+
             // Initialize separator
             case 'separator' :
                 handleSeparator(this);
                 break;
-    
+
             // Initialize cover card
             case 'cover' :
                 handleCover(this);
                 break;
-    
+
             // Intitalize empty card
             case 'empty-column' :
                 handleEmptyColumn(this);
                 break;
 
             // Initialize horizontal buttons stack
-            case 'horizontal-buttons-stack' : 
+            case 'horizontal-buttons-stack' :
                 handleHorizontalButtonsStack(this);
                 break;
-        }
-
-        if (!window.columnFix) {
-            window.columnFix = this.config.column_fix
         }
     }
 

--- a/src/cards/horizontal-buttons-stack.ts
+++ b/src/cards/horizontal-buttons-stack.ts
@@ -5,19 +5,17 @@ import {
     isColorCloseToWhite,
     convertToRGBA
 } from '../tools/style.ts';
-import { checkEditor } from '../tools/init.ts';
-import { 
+import {
     fireEvent,
     forwardHaptic,
     navigate
 } from '../tools/utils.ts';
 import { getVariables } from '../var/cards.ts';
 
-let editor;
-
 export function handleHorizontalButtonsStack(context) {
 
     const hass = context._hass;
+    const editor = context.editor;
 
     let {
         customStyles,
@@ -31,19 +29,15 @@ export function handleHorizontalButtonsStack(context) {
         popUpOpen
     } = getVariables(context, context.config, hass, editor);
 
-    let editorMode = setInterval(() => {
-        editor = checkEditor();
-
-        if (editor && !context.editorModeAdded) {
-            context.buttonsContainer.classList.add('editor');
-            context.card.classList.add('editor');
-            context.editorModeAdded = true;
-        } else if (!editor && context.editorModeAdded) {
-            context.buttonsContainer.classList.remove('editor');
-            context.card.classList.remove('editor');
-            context.editorModeAdded = false;
-        }
-    }, 100);
+    if (editor && !context.editorModeAdded) {
+        context.buttonsContainer.classList.add('editor');
+        context.card.classList.add('editor');
+        context.editorModeAdded = true;
+    } else if (!editor && context.editorModeAdded) {
+        context.buttonsContainer.classList.remove('editor');
+        context.card.classList.remove('editor');
+        context.editorModeAdded = false;
+    }
 
     let hideGradient = context.config.hide_gradient ? true : false;
 

--- a/src/tools/init.ts
+++ b/src/tools/init.ts
@@ -18,27 +18,3 @@ export function initializeContent(context) {
         context.content = content;
     }
 }
-
-// Check for edit mode
-
-function selectElement() {
-  try {
-    return document.querySelector("body > home-assistant")
-      .shadowRoot.querySelector("home-assistant-main")
-      .shadowRoot.querySelector("ha-drawer > partial-panel-resolver > ha-panel-lovelace")
-      .shadowRoot.querySelector("hui-root")
-      .shadowRoot.querySelector("div");
-  } catch (error) {
-    return undefined;
-  }
-}
-
-export function checkEditor() {
-    const editorElement = selectElement();
-
-    if (!editorElement) {
-        return;
-    }
-    return editorElement.classList.contains('edit-mode');
-}
-


### PR DESCRIPTION
Using `editMode` property provided by HomeAssistant cards, is way more resource efficient than querying HTML elements every 100ms

Also the `setInterval` was called on every `hass` update, and not cleaned up, it caused build up of running 100ms intervals forever for each entity update.
