### PR TITLE
chore: remove custom button from button types

### DIFF
--- a/src/cards/button/helpers.ts
+++ b/src/cards/button/helpers.ts
@@ -1,10 +1,17 @@
 import { throttle, isEntityType, getAttribute } from "../../tools/utils.ts";
 
 export function getButtonType(context) {
+  let buttonType = context.config.button_type;
+
+  if (buttonType === 'custom') {
+    console.error('Buttons "custom" have been removed. Use either "switch", "slider", "state" or  "name"');
+    buttonType = '';
+  }
+
   if (context.config.entity) {
-      return context.config.button_type || 'switch';
+      return buttonType || 'switch';
   } else {
-      return context.config.button_type || 'name';
+      return buttonType || 'name';
   }
 }
 


### PR DESCRIPTION
- Show an alert if someone uses `custom` buttons
- Default `custom` button to either `switch` or `name`