### PR TITLE
fix: avoid hbs jump on mobile safari

### DIFF
--- a/src/cards/horizontal-buttons-stack/index.ts
+++ b/src/cards/horizontal-buttons-stack/index.ts
@@ -12,8 +12,8 @@ export function handleHorizontalButtonsStack(context) {
     sortButtons(context);
     changeConfig(context);
     changeEditor(context);
-    changeLight(context);
-    changeStatus(context);
-    changeStyle(context);
     placeButtons(context);
+    changeLight(context);
+    changeStyle(context);
+    changeStatus(context);
 }


### PR DESCRIPTION
 - I fix a scenario when the HBS card jumps on Safari if there it's scrollable