### PR TITLE
fix: no-scrolling effect should still update state

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -370,7 +370,12 @@ export function applyScrollingEffect(context, element, text) {
 
     const scrollingEffect = context.config.scrolling_effect ?? true;
 
-    if (element.previousText === text || element.style.whiteSpace === 'normal') return;
+    if (element.previousText === text) return;
+    if (scrollingEffect === false && element.style.whiteSpace === 'normal') {
+      element.innerHTML = text;
+      element.previousText = text;
+      return;
+    }
 
     const classNames = element.className.split(' ');
     const className = classNames.find(name => name.startsWith('bubble-'));


### PR DESCRIPTION
When we force no scroll, there is currently no possibility to update the actual state.
I'm fixing this in this PR, closing #533 