### PR TITLE
feat: allow deep attribute in sub_buttons

### DIFF
--- a/src/tools/global-changes.ts
+++ b/src/tools/global-changes.ts
@@ -33,7 +33,7 @@ export function changeState(context) {
     }
 
     if (showAttribute && attribute) {
-        formattedAttribute = state ? context._hass.formatEntityAttributeValue(state, attribute) : '';
+        formattedAttribute = state ? context._hass.formatEntityAttributeValue(state, attribute) ?? attribute : '';
     }
 
     if (showLastChanged) {
@@ -222,7 +222,7 @@ export function changeSubButtonState(context, container = context.content, appen
 
         let displayedState = '';
         const formattedState = state && showState ? context._hass.formatEntityState(state) : '';
-        const formattedAttribute = state && attribute && showAttribute ? context._hass.formatEntityAttributeValue(state, attributeType) : '';
+        const formattedAttribute = state && attribute && showAttribute ? context._hass.formatEntityAttributeValue(state, attributeType) ?? attribute : '';
         const formattedLastChanged = state && showLastChanged ? formatDateTime(state.last_changed, context._hass.locale.language) : '';
 
         if (showName && name) displayedState += name;

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -373,7 +373,9 @@ export function getState(context, entity = context.config.entity) {
 }
 
 export function getAttribute(context, attribute, entity = context.config.entity) {
-    return context._hass.states[entity]?.attributes[attribute] ?? '';
+    if (!attribute) return '';
+
+    return eval(`context._hass.states['${entity}']?.attributes.${attribute}`) ?? '';
 }
 
 export function isEntityType(context, entityType) {


### PR DESCRIPTION
## Context

Currently, we can only get a specific attribute in the sub_buttons. If it works in the majority of the cases, we can't get data from forecast for example, which is accessed with something like: `forecast[0].templow`

## What did I do?

- I'm making an eval in the `getAttribute` method to have the possibility to get a deeper value
- I change some comparisons to compare an empty string so it allows 0 (it could be a valid value: eg. 0mm rain forecast)
- I complement the usage of `formatEntityAttributeValue`: it's not powerful enough to get deep values.