### PR TITLE
fix: Prevent the feedback element to be clicked

### DIFF
--- a/src/cards/button/styles.ts
+++ b/src/cards/button/styles.ts
@@ -159,6 +159,7 @@ export default `
         width: 100%;
         height: 100%;
         background-color: rgb(0,0,0);
+        pointer-events: none;
     }
 
     @keyframes tap-feedback {

--- a/src/tools/tap-actions.ts
+++ b/src/tools/tap-actions.ts
@@ -29,6 +29,7 @@ class ActionHandler {
 
     this.startTime = Date.now();
     clearTimeout(this.tapTimeout);
+    this.tapTimeout = null;
   }
 
   handleEnd() {
@@ -42,16 +43,16 @@ class ActionHandler {
     this.startTime = null;
 
     const doubleTapAction = this.config?.double_tap_action || this.defaultActions?.double_tap_action || { action: "toggle" };
-    const doubleTapTimeout = doubleTapAction.action === "none" ? 0 : 200;
+    const localDoubleTapTimeout = doubleTapAction.action === "none" ? 0 : doubleTapTimeout;
 
     if (holdDuration > maxHoldDuration) {
       this.sendActionEvent(this.element, this.config, 'hold', this.defaultEntity, this.defaultActions);
-    } else if (doubleTapDuration < doubleTapTimeout) {
+    } else if (doubleTapDuration < localDoubleTapTimeout) {
       this.sendActionEvent(this.element, this.config, 'double_tap', this.defaultEntity, this.defaultActions);
     } else {
       this.tapTimeout = setTimeout(() => {
         this.sendActionEvent(this.element, this.config, 'tap', this.defaultEntity, this.defaultActions);
-      }, doubleTapTimeout);
+      }, localDoubleTapTimeout);
     }
   }
 }


### PR DESCRIPTION
## Context

Trying to solve #533, I end up seeing that the feedback element became clickable and prevent the buttons to be "double_clicked"

## What did I do?

- I add a `pointer-event: none` css on the feedback element
- I clean a bit `doubleTapTimeout` to use the constant from the top of the file
- I reset the timeout variable when cleared

## Next step

Check with #533 if it solves the issue.