### PR TITLE
fix: attributes unavailable should be hidden

### DIFF
--- a/src/tools/global-changes.ts
+++ b/src/tools/global-changes.ts
@@ -16,7 +16,7 @@ import {
 export function changeState(context) {
     const buttonType = context.config.button_type;
     const state = context._hass.states[context.config.entity];
-    const attribute = context.config.attribute ?? '';
+    const attribute = getAttribute(context, context.config.attribute, context.config.entity);
 
     const defaultShowState = buttonType === 'state';
     const showName = context.config.show_name ?? true;
@@ -35,8 +35,8 @@ export function changeState(context) {
         context.content.appendChild(context.elements.stateStyles);
     }
 
-    if (showAttribute && attribute) {
-        formattedAttribute = state ? context._hass.formatEntityAttributeValue(state, attribute) ?? attribute : '';
+    if (showAttribute && context.config.attribute) {
+        formattedAttribute = state ? context._hass.formatEntityAttributeValue(state, context.config.attribute) ?? attribute : '';
     }
 
     if (showLastChanged) {


### PR DESCRIPTION
## Context

Some user report that the attributes are sometime plained displayed.

It's the case when an attribute is no longer available (for example with media players)

## What did I do

I change the attribute behavior to use the `getAttribute` method to ensure an empty string if the attribute does not exist.
