### PR TITLE
fix: 0 is a valid attributes, state or last change

### DIFF
--- a/src/tools/global-changes.ts
+++ b/src/tools/global-changes.ts
@@ -293,13 +293,13 @@ export function changeSubButtonState(context, container = context.content, appen
         // Build the displayed state string
         let displayedState = '';
         const formattedState = state && showState ? context._hass.formatEntityState(state) : '';
-        const formattedAttribute = state && attribute && showAttribute ? context._hass.formatEntityAttributeValue(state, attributeType) ?? attribute : '';
+        const formattedAttribute = state && attribute !== '' && showAttribute ? context._hass.formatEntityAttributeValue(state, attributeType) ?? attribute : '';
         const formattedLastChanged = state && showLastChanged ? formatDateTime(state.last_changed, context._hass.locale.language) : '';
 
-        if (showName && name) displayedState += name;
-        if (formattedState) displayedState += (displayedState ? ' · ' : '') + formattedState;
-        if (formattedLastChanged) displayedState += (displayedState ? ' · ' : '') + formattedLastChanged;
-        if (formattedAttribute) displayedState += (displayedState ? ' · ' : '') + formattedAttribute;
+        if (showName && name !== '') displayedState += name;
+        if (formattedState !== '') displayedState += (displayedState ? ' · ' : '') + formattedState;
+        if (formattedLastChanged !== '') displayedState += (displayedState ? ' · ' : '') + formattedLastChanged;
+        if (formattedAttribute !== '') displayedState += (displayedState ? ' · ' : '') + formattedAttribute;
 
         displayedState = displayedState.charAt(0).toUpperCase() + displayedState.slice(1);
 


### PR DESCRIPTION
### Context

If an attribute is 0 (for example 0mm rain forecasted, 0 degree, 0 km/h wind speed), it's not displayed in the sub-buttons

### What did I do

I change the conditions to check that the value is an empty string or not: empty means it is actually empty while 0 means it's actually not empty.