### PR TITLE
fix: recover icon from binary_sensors

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -75,6 +75,7 @@ export function tapFeedback(feedbackElement) {
 
 export function getIcon(context, entity = context.config.entity, icon = context.config.icon) {
     const entityType = entity?.split('.')[0];
+    const deviceClassType = getAttribute(context, "device_class", entity);
     const entityIcon = getAttribute(context, "icon", entity);
     const configIcon = icon;
     const state = getState(context, entity);
@@ -290,6 +291,7 @@ export function getIcon(context, entity = context.config.entity, icon = context.
     if (configIcon) return configIcon;
     if (entityIcon) return entityIcon;
     if (defaultIcons[entityType]) return defaultIcons[entityType];
+    if (defaultIcons[deviceClassType]) return defaultIcons[deviceClassType];
 
     return '';
 }


### PR DESCRIPTION
Context:
Binary Sensor were not recognized by Bubble Card.

What did I do:
If no icon is found, I get the one from the entity device_class