### PR TITLE
fix: support Google Wifi Online value as active

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -388,7 +388,7 @@ export function isEntityType(context, entityType) {
 }
 
 export function isStateOn(context, entity = context.config.entity) {
-    const state = getState(context, entity);
+    const state = getState(context, entity).toLowerCase();
     const numericState = Number(state);
     const activeStringStates = [
         'on', 
@@ -407,6 +407,7 @@ export function isStateOn(context, entity = context.config.entity) {
         'running', 
         'active', 
         'connected', 
+        'online',
         'mowing', 
         'starting',
         'heat',


### PR DESCRIPTION
Context:
Google Wifi has a special "Online" state when available

What did I do:
I add an "online" value to the active status
I force lowercase the state to be sure the detection is consistent