### PR TITLE
fix: do not fire hold if a scroll is made

### DIFF
--- a/src/tools/tap-actions.ts
+++ b/src/tools/tap-actions.ts
@@ -1,6 +1,6 @@
 import { tapFeedback, forwardHaptic } from "./utils.ts";
 
-const maxHoldDuration = 200;
+const maxHoldDuration = 500;
 const doubleTapTimeout = 200;
 
 // Global event listener
@@ -30,6 +30,7 @@ document.body.addEventListener('pointerdown', (event) => {
     actionElement.actionHandler.handleStart(event);
 
     actionElement.addEventListener('pointerup', actionElement.actionHandler.handleEnd.bind(actionElement.actionHandler), { once: true });
+    document.addEventListener('scroll', actionElement.actionHandler.handleScroll.bind(actionElement.actionHandler), { once: true });
   }
 });
 
@@ -153,6 +154,12 @@ class ActionHandler {
     // Update lastTap timestamp
     this.lastTap = currentTime;
     this.startTime = null;  // Reset start time
+  }
+
+  handleScroll() {
+    // Reset hold timeout if it's not triggered yet
+    clearTimeout(this.holdTimeout);
+    this.holdTimeout = null; // Reset hold timeout
   }
 }
 


### PR DESCRIPTION
Context:
Hold action is fired too fast and prevent the scroll

What did I do:
- I change the delay to 500ms to be consistent with Home Assistant hold delay
- I reset the timer on scroll