### PR TITLE
Fixes missing '•' when state is not shown but Attribute and LastChanged are

### DIFF
--- a/src/tools/global-changes.ts
+++ b/src/tools/global-changes.ts
@@ -74,7 +74,9 @@ export function changeState(context) {
         }
     }
 
-    displayedState = formattedState + (formattedAttribute ? `${showState ? ' • ' : ''}${formattedAttribute}` : '') + (formattedLastChanged ? `${showState ? ' • ' : ''}${formattedLastChanged}` : '');
+    displayedState = [formattedState, formattedAttribute, formattedLastChanged]
+        .filter((item) => item)
+        .join(' • ');
 
     if (!showName) {
         context.elements.name.classList.add('hidden');


### PR DESCRIPTION
Before fix:
<img width="441" alt="Screenshot 2024-10-25 at 13 58 14" src="https://github.com/user-attachments/assets/79118bab-a7fc-4ca5-b826-94a5fccf38ce">

After fix:
<img width="444" alt="Screenshot 2024-10-25 at 13 58 48" src="https://github.com/user-attachments/assets/1043a6aa-8a33-436a-8348-92420b55be04">
