### PR TITLE
Add check if sub-button-container exist and then set opacity

### DIFF
--- a/src/cards/media-player/changes.ts
+++ b/src/cards/media-player/changes.ts
@@ -168,7 +168,7 @@ export function changeVolumeIcon(context) {
     context.elements.volumeButton.setAttribute("icon", newIcon);
     context.elements.mediaInfoContainer.style.opacity = newOpacity;
     context.elements.nameContainer.style.opacity = newOpacity;
-    context.elements.subButtonContainer.style.opacity = newOpacity;
+    if(context.elements.subButtonContainer)context.elements.subButtonContainer.style.opacity = newOpacity;
     context.elements.previousButton.style.opacity = newOpacity;
     context.elements.nextButton.style.opacity = newOpacity;
     context.elements.powerButton.style.opacity = newOpacity;


### PR DESCRIPTION
Solves
---
#994 

Cause
---
The opacity was set on the sub-button-container without checking if this existed. 

Solution
---
Check if sub-button exist before setting the opacity.