### PR TITLE
fix: attribute fallbacks within getImage

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -434,11 +434,9 @@ export function getIconColor(context, entity = context.config.entity, brightness
 export function getImage(context, entity = context.config.entity) {
     if (context.config.force_icon) return '';
 
-    const stateObj = context._hass.states[entity];
-
     const entityPicture =
-      stateObj.attributes.entity_picture_local ||
-      stateObj.attributes.entity_picture;
+      getAttribute(context, "entity_picture_local", entity) ||
+      getAttribute(context, "entity_picture", entity);
 
     if (!entityPicture) return '';
 


### PR DESCRIPTION
Hi @Clooos 👋 

I started receiving some errors when I upgraded from 2.3.0 to 2.3.1 (and higher). Not an expert by any means but I believe the below error can be easily fixed by adding a safety net when fetching attributes (in case an entity is not provided).

![Screenshot 2024-12-13 at 15 40 17](https://github.com/user-attachments/assets/5d6f2cb7-30eb-4d5d-a409-f7992f785ff5)

I tested this locally and it seems to work fine.
