### PR TITLE
fix(h-buttons-stack): #780 unstable order, if PIR missing

### DIFF
--- a/src/cards/horizontal-buttons-stack/changes.ts
+++ b/src/cards/horizontal-buttons-stack/changes.ts
@@ -12,7 +12,7 @@ export function sortButtons(context) {
 
     context.elements.buttons.sort((a, b) => {
         if (!states[a.pirSensor]) return 1;
-        if (!states[a.pirSensor]) return -1;
+        if (!states[b.pirSensor]) return -1;
 
         const aTime = states[a.pirSensor]?.last_updated;
         const bTime = states[b.pirSensor]?.last_updated;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
This is an attempt to fix #780, where the order of the buttons in the horizontal buttons stack would constantly flip around, if any button has no PIR sensor attached.

I couldn't test this change yet, but looking at the code, there seems to be an obvious typo, that explains the buggy behavior well.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

Note the missing `4_pir_sensor` for Settings. All other buttons have one defined.

```yaml
type: custom:bubble-card
card_type: horizontal-buttons-stack
auto_order: true
1_link: "#living-room"
1_name: Living Room
1_icon: mdi:sofa-outline
1_entity: light.couch
2_link: "#dining"
2_name: Dining
2_icon: hue:room-dining
2_entity: light.dining_area
3_link: "#bedroom"
3_name: Bedroom
3_icon: mdi:bed-king-outline
3_entity: light.bedroom
4_link: "#settings"
4_name: Settings
4_icon: mdi:wrench-outline
1_pir_sensor: binary_sensor.kitchen_motion_sensor_occupancy
2_pir_sensor: binary_sensor.kitchen_motion_sensor_occupancy
3_pir_sensor: binary_sensor.bedroom_motion_sensor_occupancy
highlight_current_view: true
hide_gradient: false
5_link: "#bathroom"
5_name: Bathroom
5_icon: mdi:paper-roll-outline
5_entity: light.bathroom_lights
5_pir_sensor: binary_sensor.bathroom_motion_sensor_occupancy
6_link: "#office"
6_name: Office
6_icon: mdi:desk
6_entity: light.office_desk
6_pir_sensor: binary_sensor.office_motion_sensor_occupancy
width_desktop: ""
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->
![Screen Recording 2025-01-13 at 01 53 44](https://github.com/user-attachments/assets/c7516204-4e4d-46ca-bffb-9244d0634a0c)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #780 
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->

Thank you for this amazing addon! You rock! ✨ 