### PR TITLE
feat(show_last_updated): initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ This card allows you to control your entities and can be customized in many ways
 | `show_name` | boolean | Optional | `true` (default) or `false` | Show or hide the name |
 | `show_icon` | boolean | Optional | `true` (default) or `false` | Show or hide the icon |
 | `show_last_changed` | boolean | Optional | `true` or `false` (default) | Show the last changed time of your `entity` |
+| `show_last_updated` | boolean | Optional | `true` or `false` (default) | Show the last updated time of your `entity` |
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
@@ -547,6 +548,7 @@ This card allows you to control a media player. You can tap on the icon to get m
 | `show_name` | boolean | Optional | `true` (default) or `false` | Show or hide the name |
 | `show_icon` | boolean | Optional | `true` (default) or `false` | Show or hide the icon |
 | `show_last_changed` | boolean | Optional | `true` or `false` (default) | Show the last changed time of your `entity` |
+| `show_last_updated` | boolean | Optional | `true` or `false` (default) | Show the last updated time of your `entity` |
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
@@ -664,6 +666,7 @@ This card allows you to control your `cover` entities.
 | `show_name` | boolean | Optional | `true` (default) or `false` | Show or hide the name |
 | `show_icon` | boolean | Optional | `true` (default) or `false` | Show or hide the icon |
 | `show_last_changed` | boolean | Optional | `true` or `false` (default) | Show the last changed time of your `entity` |
+| `show_last_updated` | boolean | Optional | `true` or `false` (default) | Show the last updated time of your `entity` |
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
@@ -750,6 +753,7 @@ This card allows you to add a dropdown menu for your `input_select` / `select` e
 | `show_name` | boolean | Optional | `true` (default) or `false` | Show or hide the name |
 | `show_icon` | boolean | Optional | `true` (default) or `false` | Show or hide the icon |
 | `show_last_changed` | boolean | Optional | `true` or `false` (default) | Show the last changed time of your `entity` |
+| `show_last_updated` | boolean | Optional | `true` or `false` (default) | Show the last updated time of your `entity` |
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
@@ -1010,6 +1014,7 @@ In every card that supports that option, you can add sub-buttons to customize yo
 | `show_name` | boolean | Optional | `true` or `false` (default) | Show or hide the name |
 | `show_icon` | boolean | Optional | `true` (default) or `false` | Show or hide the icon |
 | `show_last_changed` | boolean | Optional | `true` or `false` (default) | Show the last changed time of your `entity` |
+| `show_last_updated` | boolean | Optional | `true` or `false` (default) | Show the last updated time of your `entity` |
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on sub-button click, if undefined, `more-info` will be used. |

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -352,6 +352,18 @@ class BubbleCardEditor extends LitElement {
                     <label class="mdc-label">Optional - Show last changed</label> 
                 </div>
             </ha-formfield>
+            <ha-formfield .label="Optional - Show last updated">
+                <ha-switch
+                    aria-label="Optional - Show last updated"
+                    .checked=${context?.show_last_updated}
+                    .configValue="${config + "show_last_updated"}"
+                    .disabled="${nameButton && array !== 'sub_button'}"
+                    @change="${!array ? this._valueChanged : (ev) => this._arrayValueChange(index, { show_last_updated: ev.target.checked }, array)}"
+                ></ha-switch>
+                <div class="mdc-form-field">
+                    <label class="mdc-label">Optional - Show last updated</label> 
+                </div>
+            </ha-formfield>
             <ha-formfield .label="Optional - Show attribute">
                 <ha-switch
                     aria-label="Optional - Show attribute"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

I would not consider it a breaking change as it only breaks an undocumented and incorrect behavior. However, for clarity's sake...

In the `yaml` if you were using `show_last_updated` instead of `show_last_changed`, it will now actually show the last updated value instead of the current behavior of showing the last changed value. This behavior in my opinion is a bug but wanted to state it here in case it [broke someone's workflow](https://xkcd.com/1172/). 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Fixes a bug. I can make a bug report if you want. I had not as I thought I'd just make a PR instead. 

The bug is that `show_last_updated` in the yaml is treated as an alias for `show_last_changed`. This means if someone were to use it, the resulting time stamp would be incorrect since last changed and last updated, although can be the same value, are not always. This also adds the key into the GUI editor. 


In this screenshot the first timestamp is `last_changed` and the second is `last_updated`. I was unsure which to make show up first so arbitrarily `last_updated` is shown second.
![image](https://github.com/user-attachments/assets/178e28ac-62c1-4681-9556-dcc2f68b16c1)



## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: custom:bubble-card
card_type: button
modules:
  - default
button_type: state
entity: light.living_room
show_last_updated: true
show_attribute: false

```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->
Before it showed `last_changed` when requesting `last_updated`
![image](https://github.com/user-attachments/assets/6aba62ce-fd4b-45d2-bb76-241682aa5b56)

After it shows `last_updated` when requested
![image](https://github.com/user-attachments/assets/b0335125-93e6-4de4-8fe3-9cc8e0e0f7db)

Can also show both
![image](https://github.com/user-attachments/assets/40b58358-1ccb-4145-a78a-88065b3ff44b)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I think the above pretty sufficiently describes what this PR does but happy to answer any questions. The motivation behind this PR is that some sensors like `waze_travel_time` I like to see when it was last _updated_ as opposed to _changed_ so that I know how recently it determined person xyz is 45 min away. If someone stays still for an hour, `last_changed` will show 1 hour ago but `last_updated` will show (usually) up to 5 min ago (assuming a 5 min update interval which is the default in this case).

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->

The documentation was added to the readme. 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->
