### PR TITLE
fix(modules): prioritize the styles written in the card over modules

### DIFF
--- a/src/tools/style-utils.js
+++ b/src/tools/style-utils.js
@@ -108,7 +108,7 @@ export const handleCustomStyles = async (context, element = context.card) => {
 
   const evaluatedCustomStyles = evalStyles(context, customStyles);
   const evaluatedCombinedStyles = evalStyles(context, combinedStyles);
-  const finalStyles = `${evaluatedCustomStyles}\n${evaluatedCombinedStyles}`.trim();
+  const finalStyles = `${evaluatedCombinedStyles}\n${evaluatedCustomStyles}`.trim();
 
   if (finalStyles !== context.lastEvaluatedStyles) {
     styleElement.textContent = finalStyles;

--- a/src/tools/style-utils.js
+++ b/src/tools/style-utils.js
@@ -106,8 +106,8 @@ export const handleCustomStyles = async (context, element = context.card) => {
     combinedStyles = tmpl;
   }
 
-  const evaluatedCustomStyles = evalStyles(context, customStyles);
   const evaluatedCombinedStyles = evalStyles(context, combinedStyles);
+  const evaluatedCustomStyles = evalStyles(context, customStyles);
   const finalStyles = `${evaluatedCombinedStyles}\n${evaluatedCustomStyles}`.trim();
 
   if (finalStyles !== context.lastEvaluatedStyles) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

Bug: card customization is ignored if a module applies the same css

Description:
Prioritize the customization performed at the card's `styles` attribute over the module. Since the card's `styles` attribute is card specific it makes sense that that should override anything in a `module` seeing how modules are generic. This will allow user's to customize modules or set default behavior but override that behavior under certain conditions. For example, my use case where I discovered this bug was that I had a default animation for all my icons but fans spun. The way the code is written today, the fan would never spin and instead only ever do that default animation.

Remaining consistent, this also makes the JS from the card's `style` run second. This allows the user's js to customize things set by modules. In my use case, I am using the [get_state_attribute](https://github.com/Clooos/Bubble-Card/discussions/1232) module for my roborock vacuum in order to display it's status from another entity the integration provides. However, it will show `charging` even once fully charged. In that case, I'd like it to display the default `docked`. So I wrote a `styles` that will check the status and if its `charging` and the battery level is `100` then it swaps `.bubble-state` back to the original state. 

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

Here is the code from the screenshots.

Module
```yaml
default:
  name: Default
  description: Empty and enabled by default. Move your styles/templates here to apply them to all cards.
  code: |
    ha-icon,
    .icon {
        color: red;
    }
```

Dashboard:
```yaml
type: grid
cards:
  - type: custom:bubble-card
    card_type: separator
    modules: []
    button_type: name
    name: No modules nor styles
    icon: mdi:home-assistant
  - type: custom:bubble-card
    card_type: separator
    modules:
      - default
    button_type: name
    name: Only has "default" module
    icon: mdi:home-assistant
  - type: custom:bubble-card
    card_type: separator
    modules:
      - default
    button_type: name
    name: Has default module and card specific style
    icon: mdi:home-assistant
    styles: |2
          ha-icon,
          .icon {
              color: blue;
          }
  - type: custom:bubble-card
    card_type: separator
    modules: []
    button_type: name
    name: Only has card specific style
    icon: mdi:home-assistant
    styles: |2
          ha-icon,
          .icon {
              color: blue;
          }
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->

Before:
![image](https://github.com/user-attachments/assets/26c5fdb4-1336-4526-a286-3854c299864c)

After:
![image](https://github.com/user-attachments/assets/d60178d1-417c-4735-9b6b-99d108ae64b2)


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion: https://github.com/Clooos/Bubble-Card/discussions/1262#discussioncomment-12294748
- Link to documentation pull request:

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->
