### PR TITLE
[FEAT] Analog/smooth brightness control with light sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ This card allows you to control your entities and can be customized in many ways
 | `sub_button` | object | Optional | See [sub-buttons](#sub-buttons) | Add customized buttons fixed to the right |
 | `slider_live_update` | boolean | Optional (`button_type` must be set to `slider`) | `true` or `false` (default) | If toggled, value is updated while sliding instead of only on release |
 | `enable_light_transition` | boolean | Optional (`button_type` must be set to `slider` and entity must be of type `light`) | `true` or `false` (default) | If toggled, enables smooth brightness transitions for light. Note: your light must support the `light.turn_on` `transition` property. |
-| `light_transition_time` | number | Options (`button_type` must be set to `slider`, entity must be of type `light`, and `enable_light_transition` must be toggled) | `0`ms to `2000`ms (default `500ms`) | Provide transition time for brightness adjustments | 
+| `light_transition_time` | number | Optional (`button_type` must be set to `slider`, entity must be of type `light`, and `enable_light_transition` must be toggled) | `0`ms to `2000`ms (default `500`ms) | Provide transition time for smooth brightness adjustments - recommend > `200`ms | 
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ This card allows you to control your entities and can be customized in many ways
 | `rows` | string | Optional | `1` (default), `2`, `3` or `4` | Number of rows when placed in a **section view** (e.g. `2` is 2/4) |
 | `sub_button` | object | Optional | See [sub-buttons](#sub-buttons) | Add customized buttons fixed to the right |
 | `slider_live_update` | boolean | Optional (`button_type` must be set to `slider`) | `true` or `false` (default) | If toggled, value is updated while sliding instead of only on release |
+| `enable_light_transition` | boolean | Optional (`button_type` must be set to `slider` and entity must be of type `light`) | `true` or `false` (default) | If toggled, enables smooth brightness transitions for light. Note: your light must support the `light.turn_on` `transition` property. |
+| `light_transition_time` | number | Options (`button_type` must be set to `slider`, entity must be of type `light`, and `enable_light_transition` must be toggled) | `0`ms to `2000`ms (default `500ms`) | Provide transition time for brightness adjustments | 
 
 </details>
 

--- a/src/cards/button/changes.js
+++ b/src/cards/button/changes.js
@@ -10,7 +10,8 @@ import {
   getAttribute,
   isStateOn,
   isEntityType,
-  setLayout
+  setLayout,
+  MAX_BRIGHTNESS
 } from '../../tools/utils.js';
 import { handleCustomStyles } from '../../tools/style-utils.js';
 
@@ -136,7 +137,7 @@ export function changeSlider(context) {
     let percentage = 0;
 
     if (isEntityType(context, "light")) {
-      percentage = 100 * getAttribute(context, "brightness") / 255;
+      percentage = 100 * getAttribute(context, "brightness") / MAX_BRIGHTNESS;
     } else if (isEntityType(context, "media_player")) {
       if (isStateOn(context)) {
         percentage = 100 * getAttribute(context, "volume_level");

--- a/src/cards/button/helpers.js
+++ b/src/cards/button/helpers.js
@@ -30,12 +30,14 @@ export function updateEntity(context, value) {
 
   if (isEntityType(context, "light")) {
     const isTransitionEnabled = context.config.enable_light_transition;
-    const transitionTime = (context.config.light_transition_time ?? DEFAULT_LIGHT_TRANSITION_TIME) / 1000;
+    const transitionTime = (context.config.light_transition_time === "" || isNaN(context.config.light_transition_time))
+                                ? DEFAULT_LIGHT_TRANSITION_TIME 
+                                : context.config.light_transition_time;
 
     context._hass.callService('light', 'turn_on', {
       entity_id: context.config.entity,
       brightness: Math.round(MAX_BRIGHTNESS * value / 100),
-      ...(isTransitionEnabled && { transition: transitionTime })
+      ...(isTransitionEnabled && { transition: transitionTime / 1000 })
     });
   } else if (isEntityType(context, "media_player")) {
       context._hass.callService('media_player', 'volume_set', {

--- a/src/cards/button/helpers.js
+++ b/src/cards/button/helpers.js
@@ -20,15 +20,13 @@ export function updateEntity(context, value) {
   const state = context._hass.states[context.config.entity];
 
   if (isEntityType(context, "light")) {
-    const isTransitionEnabled = context.config.enable_brightness_transition ?? false;
-    const transitionTime = isTransitionEnabled
-                            ? (Number(context.config.brightness_transition_time) || 0)
-                            : 0;
-  
-    context._hass.callService("light", "turn_on", {
+    const isTransitionEnabled = context.config.enable_light_transition;
+    const transitionTime = isTransitionEnabled ? (context.config.light_transition_time / 1000) : 0;
+
+    context._hass.callService('light', 'turn_on', {
       entity_id: context.config.entity,
       brightness: Math.round(255 * value / 100),
-      transition: transitionTime,
+      ...(isTransitionEnabled && { transition: transitionTime })
     });
   } else if (isEntityType(context, "media_player")) {
       context._hass.callService('media_player', 'volume_set', {

--- a/src/cards/button/helpers.js
+++ b/src/cards/button/helpers.js
@@ -20,10 +20,16 @@ export function updateEntity(context, value) {
   const state = context._hass.states[context.config.entity];
 
   if (isEntityType(context, "light")) {
-      context._hass.callService('light', 'turn_on', {
-          entity_id: context.config.entity,
-          brightness: Math.round(255 * value / 100)
-      });
+    const isTransitionEnabled = context.config.enable_brightness_transition ?? false;
+    const transitionTime = isTransitionEnabled
+                            ? (Number(context.config.brightness_transition_time) || 0)
+                            : 0;
+  
+    context._hass.callService("light", "turn_on", {
+      entity_id: context.config.entity,
+      brightness: Math.round(255 * value / 100),
+      transition: transitionTime,
+    });
   } else if (isEntityType(context, "media_player")) {
       context._hass.callService('media_player', 'volume_set', {
           entity_id: context.config.entity,

--- a/src/cards/button/helpers.js
+++ b/src/cards/button/helpers.js
@@ -1,5 +1,14 @@
 import { addActions, addFeedback } from "../../tools/tap-actions.js";
-import { createElement, toggleEntity, throttle, forwardHaptic, isEntityType, getAttribute } from "../../tools/utils.js";
+import { 
+    createElement, 
+    toggleEntity, 
+    throttle, 
+    forwardHaptic, 
+    isEntityType, 
+    getAttribute, 
+    DEFAULT_LIGHT_TRANSITION_TIME, 
+    MAX_BRIGHTNESS 
+} from "../../tools/utils.js";
 
 export function getButtonType(context) {
   let buttonType = context.config.button_type;
@@ -21,11 +30,11 @@ export function updateEntity(context, value) {
 
   if (isEntityType(context, "light")) {
     const isTransitionEnabled = context.config.enable_light_transition;
-    const transitionTime = isTransitionEnabled ? (context.config.light_transition_time / 1000) : 0;
+    const transitionTime = (context.config.light_transition_time ?? DEFAULT_LIGHT_TRANSITION_TIME) / 1000;
 
     context._hass.callService('light', 'turn_on', {
       entity_id: context.config.entity,
-      brightness: Math.round(255 * value / 100),
+      brightness: Math.round(MAX_BRIGHTNESS * value / 100),
       ...(isTransitionEnabled && { transition: transitionTime })
     });
   } else if (isEntityType(context, "media_player")) {

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -417,23 +417,21 @@ class BubbleCardEditor extends LitElement {
                     </div>
                 </ha-formfield>
                 ${this._config.enable_light_transition ? html`
+                    <ha-alert alert-type="info">
+                        <span style="font-weight: bold;">Important</span> – This feature only works for lights that support the 
+                        <a target="_blank" rel="noopener noreferrer" href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">light.turn_on</a> transition attribute. 
+                        Enabling this for lights that do not support transitions will unfortunatley have no effect. Defaults to 500ms unless overridden below.
+                    </ha-alert>
+                    
                     <ha-textfield
                         label="Transition time (ms)"
                         type="number"
-                        min="0"
+                        min="1"
                         max="2000"
-                        .value="${this._config.light_transition_time ?? DEFAULT_LIGHT_TRANSITION_TIME}"
+                        .value="${this._config.light_transition_time}"
                         .configValue="${"light_transition_time"}"
                         @input="${this._valueChanged}"
                     ></ha-textfield>
-                    <ha-alert alert-type="info">
-                        Transition time in ms for brightness adjustments. When combined with slider live updates, it enables smooth, real-time updates. 
-                        Try starting with 500ms if combined with live updates for an analog dimmer style experience!
-
-                        <br><span style="font-weight: bold;">Important</span> – This feature only works for lights that support the 
-                        <a target="_blank" rel="noopener noreferrer" href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">light.turn_on</a> transition attribute. 
-                        Enabling this for lights that do not support transitions will unfortunatley have no effect. 
-                    </ha-alert>
                 ` : ''}
               ` : ''}
         `;

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -222,6 +222,7 @@ class BubbleCardEditor extends LitElement {
         const nameButton = this._config.button_type === 'name';
 
         const isSelect = entity?.startsWith("input_select") || entity?.startsWith("select") || context.select_attribute;
+        const isLight = entity?.startsWith("light");
 
         const attributeList = Object.keys(this.hass.states[entity]?.attributes || {}).map((attributeName) => {
             let state = this.hass.states[entity];
@@ -403,6 +404,37 @@ class BubbleCardEditor extends LitElement {
                 </ha-formfield>
                 <ha-alert alert-type="info">By default, sliders are updated only on release. You can toggle this option to enable live updates while sliding.</ha-alert>
             ` : ''}
+            ${array !== 'sub_button' && this._button_type === 'slider' && isLight ? html`
+                <ha-formfield .label="Optional - Enable smooth brightness transitions">
+                    <ha-switch
+                        aria-label="Optional - Enable smooth brightness transitions"
+                        .checked=${this._config.enable_brightness_transition ?? false}
+                        .configValue="${"enable_brightness_transition"}"
+                        @change=${this._valueChanged}
+                    ></ha-switch>
+                    <div class="mdc-form-field">
+                        <label class="mdc-label">Optional - Enable smooth brightness transitions</label> 
+                    </div>
+                </ha-formfield>
+                ${this._config.enable_brightness_transition ? html`
+                    <ha-textfield
+                        label="Transition time (ms)"
+                        type="number"
+                        min="0"
+                        max="2000"
+                        .value="${this._config.brightness_transition_time ?? 500}"
+                        .configValue="${"brightness_transition_time"}"
+                        @input="${this._valueChanged}"
+                    ></ha-textfield>
+                    <ha-alert alert-type="info">
+                        Important – This option applies only to lights that offer the 
+                        <a href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">
+                            transition
+                        </a> attribute. 
+                        When combined with slider live updates, it enables smooth, real-time brightness adjustments. Try starting with 500ms if combined with live updates.
+                    </ha-alert>
+                ` : ''}
+              ` : ''}
         `;
     }
 

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -23,7 +23,9 @@ class BubbleCardEditor extends LitElement {
 
     setConfig(config) {
         this._config = {
-            ...config
+            ...config,
+            // Set default transition time to 500ms for smooth light slider transitions
+            light_transition_time: config.light_transition_time ?? 500
         };
     }
 
@@ -408,30 +410,28 @@ class BubbleCardEditor extends LitElement {
                 <ha-formfield .label="Optional - Enable smooth brightness transitions">
                     <ha-switch
                         aria-label="Optional - Enable smooth brightness transitions"
-                        .checked=${this._config.enable_brightness_transition ?? false}
-                        .configValue="${"enable_brightness_transition"}"
+                        .checked=${this._config.enable_light_transition ?? false}
+                        .configValue="${"enable_light_transition"}"
                         @change=${this._valueChanged}
                     ></ha-switch>
                     <div class="mdc-form-field">
                         <label class="mdc-label">Optional - Enable smooth brightness transitions</label> 
                     </div>
                 </ha-formfield>
-                ${this._config.enable_brightness_transition ? html`
+                ${this._config.enable_light_transition ? html`
                     <ha-textfield
                         label="Transition time (ms)"
                         type="number"
                         min="0"
                         max="2000"
-                        .value="${this._config.brightness_transition_time ?? 500}"
-                        .configValue="${"brightness_transition_time"}"
+                        .value="${this._config.light_transition_time}"
+                        .configValue="${"light_transition_time"}"
                         @input="${this._valueChanged}"
                     ></ha-textfield>
                     <ha-alert alert-type="info">
-                        Important – This option applies only to lights that offer the 
-                        <a href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">
-                            transition
-                        </a> attribute. 
-                        When combined with slider live updates, it enables smooth, real-time brightness adjustments. Try starting with 500ms if combined with live updates.
+                        <span style="font-weight: bold;">Important</span> – This option only applies to lights that support the 
+                        <a target="_blank" rel="noopener noreferrer" href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">light.turn_on</a> transition attribute. 
+                        <br><br>When combined with slider live updates, it enables smooth, real-time brightness adjustments. Try starting with 500ms if combined with live updates.
                     </ha-alert>
                 ` : ''}
               ` : ''}

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -5,7 +5,7 @@ import {
     unsafeCSS
 } from 'lit';
 import { version } from '../var/version.js';
-import { fireEvent } from '../tools/utils.js';
+import { fireEvent, DEFAULT_LIGHT_TRANSITION_TIME } from '../tools/utils.js';
 import { renderButtonEditor } from '../cards/button/editor.js';
 import { renderPopUpEditor } from '../cards/pop-up/editor.js';
 import { renderSeparatorEditor } from '../cards/separator/editor.js';
@@ -23,9 +23,7 @@ class BubbleCardEditor extends LitElement {
 
     setConfig(config) {
         this._config = {
-            ...config,
-            // Set default transition time to 500ms for smooth light slider transitions
-            light_transition_time: config.light_transition_time ?? 500
+            ...config
         };
     }
 
@@ -224,7 +222,7 @@ class BubbleCardEditor extends LitElement {
         const nameButton = this._config.button_type === 'name';
 
         const isSelect = entity?.startsWith("input_select") || entity?.startsWith("select") || context.select_attribute;
-        const isLight = entity?.startsWith("light");
+        const isLight = entity?.startsWith("light") ?? false;
 
         const attributeList = Object.keys(this.hass.states[entity]?.attributes || {}).map((attributeName) => {
             let state = this.hass.states[entity];
@@ -270,7 +268,7 @@ class BubbleCardEditor extends LitElement {
                     </div>
                 </ha-formfield>
             ` : ''}
-            ${array === 'sub_button' && (context?.state_background ?? true) && entity.startsWith("light") ? html`
+            ${array === 'sub_button' && (context?.state_background ?? true) && isLight ? html`
                 <ha-formfield .label="Optional - Background color based on light color">
                     <ha-switch
                         aria-label="Optional - Background color based on light color"
@@ -282,7 +280,7 @@ class BubbleCardEditor extends LitElement {
                     </div>
                 </ha-formfield>
             ` : ''}
-            ${array !== 'sub_button' && entity.startsWith("light") ? html`
+            ${array !== 'sub_button' && isLight ? html`
                 <ha-formfield .label="Optional - Use accent color instead of light color">
                     <ha-switch
                         aria-label="Optional - Use accent color instead of light color"
@@ -424,7 +422,7 @@ class BubbleCardEditor extends LitElement {
                         type="number"
                         min="0"
                         max="2000"
-                        .value="${this._config.light_transition_time}"
+                        .value="${this._config.light_transition_time ?? DEFAULT_LIGHT_TRANSITION_TIME}"
                         .configValue="${"light_transition_time"}"
                         @input="${this._valueChanged}"
                     ></ha-textfield>

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -427,9 +427,12 @@ class BubbleCardEditor extends LitElement {
                         @input="${this._valueChanged}"
                     ></ha-textfield>
                     <ha-alert alert-type="info">
-                        <span style="font-weight: bold;">Important</span> – This option only applies to lights that support the 
+                        Transition time in ms for brightness adjustments. When combined with slider live updates, it enables smooth, real-time updates. 
+                        Try starting with 500ms if combined with live updates for an analog dimmer style experience!
+
+                        <br><span style="font-weight: bold;">Important</span> – This feature only works for lights that support the 
                         <a target="_blank" rel="noopener noreferrer" href="https://www.home-assistant.io/integrations/light/#action-lightturn_on">light.turn_on</a> transition attribute. 
-                        <br><br>When combined with slider live updates, it enables smooth, real-time brightness adjustments. Try starting with 500ms if combined with live updates.
+                        Enabling this for lights that do not support transitions will unfortunatley have no effect. 
                     </ha-alert>
                 ` : ''}
               ` : ''}

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -1,5 +1,8 @@
 import { isColorCloseToWhite } from "./style.js";
 
+export const DEFAULT_LIGHT_TRANSITION_TIME = 500; // in milliseconds
+export const MAX_BRIGHTNESS = 255;
+
 export const fireEvent = (node, type, detail, options) => {
     options = options || {};
     detail = detail === null || detail === undefined ? {} : detail;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This feature allows the slider to emulate an analog light dimmer, especially if paired with the slider live updates feature. In addition to toggling the feature on, a user may also provide a custom transition time (in milliseconds) from a soft minimum of 1 to a soft maximum of 2000ms (if configured solely through the visual editor) - I arbitrarily chose this max value as I cannot imagine a user would want to set it any higher but ¯\ \_(ツ)_/¯ . By default, this transition time is set to 500ms as I found this to strike the perfect balance between seamless brightness transitions and perceived responsiveness..

The smooth transition feature works by leveraging the `light.turn_on` `transition` data attribute. Unfortunately, not all lights support the `transition` data attribute (eg. Tapo) :( Fortunately, however, enabling this feature for such lights is entirely harmless.

This logic is equally applicable to other data attributes such as `rgb_color` or `color_temp_kelvin` depending on how the planned light slider controls for these two are implemented :) We'll just have to reword a few things here and there, eg. Optional - Enable smooth **brightness** transitions -> Optional - Enable smooth **light** transitions, etc.

The optional features are only exposed to the user if the card type is a slider and the associated entity is of type 'light'.

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

Without transition time override
```yaml
type: custom:bubble-card
card_type: button
modules:
  - default
button_type: slider
entity: light.ankarspel
slider_live_update: true
enable_light_transition: true
```

With transition time override
```yaml
type: custom:bubble-card
card_type: button
modules:
  - default
button_type: slider
entity: light.ankarspel
slider_live_update: true
enable_light_transition: true
light_transition_time: "300"
```

## Example printscreens/gif

### Smooth transitions disabled:

Editor config

<img width="337" alt="image" src="https://github.com/user-attachments/assets/2cfa3f41-9507-4fc4-a66e-03b7e559f635" />

Video (effectively the old behavior)

https://github.com/user-attachments/assets/6d7ad2de-21c7-4faf-8c61-4f6da96cb79a

### Smooth transitions enabled:

Editor config

<img width="337" alt="image" src="https://github.com/user-attachments/assets/7faf6988-1b23-4242-b38f-d5cb0e1b23be" />

Video

https://github.com/user-attachments/assets/1621ed12-8d17-4b32-96f3-3303f769d988

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: N/A
- Link to documentation pull request: N/A (readme update included in this PR)

## Additional documentation needed.

To enable this feature, simply toggle **Optional - Enable smooth brightness transitions** and override the default transition time if desired.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->
