### PR TITLE
Fix sluggish buttons when double-tap is disabled

### DIFF
--- a/src/tools/tap-actions.js
+++ b/src/tools/tap-actions.js
@@ -197,9 +197,13 @@ class ActionHandler {
       clearTimeout(this.tapTimeout);
       this.sendActionEvent(this.element, this.config, 'double_tap');
     } else if (tapAction.action !== 'none') {
-      this.tapTimeout = setTimeout(() => {
+      if (doubleTapAction.action !== 'none') {
+        this.tapTimeout = setTimeout(() => {
+          this.sendActionEvent(this.element, this.config, 'tap');
+        }, doubleTapTimeout);
+      } else {
         this.sendActionEvent(this.element, this.config, 'tap');
-      }, doubleTapTimeout);
+      }
     }
 
     this.lastTap = currentTime;


### PR DESCRIPTION
In order to differentiate between a single tap and a double tap, there needs to be a delay after the first tap. Otherwise, the action of the first tap will be executed prematurely.

Unfortunately, that adds a delay to any single tap action. In this case, the delay was set to 200 milliseconds, which is way more than the latency of many devices.

The solution is simple – in most cases, people don't even use double tap, so we can avoid the delay entirely. That's what this commit does.

Tested locally, works great, the difference is very noticeable.

Related discussion: https://github.com/Clooos/Bubble-Card/discussions/288