### PR TITLE
Switch the default double-tap action to `none`

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ This card allows you to control your entities and can be customized in many ways
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
 | `button_action` | object | Optional | `tap_action`, `double_tap_action` or `hold_action`, see below | Allow to change the default actions on button click. Not available for the `slider` type |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon click, if undefined, `more-info` will be used |
-| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `toggle` will be used |
+| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `none` will be used |
 | `hold_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon hold, if undefined, `more-info` will be used |
 | `card_layout` | string | Optional | `normal` (default), `large`, `large-2-rows` | Styling layout of the card, see [card layouts](#card-layouts) |
 | `columns` | string | Optional | `1`, `2`, `3` or `4` (default) | Number of columns when placed in a **section view** (e.g. `2` is 2/4) |
@@ -553,7 +553,7 @@ This card allows you to control a media player. You can tap on the icon to get m
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon click, if undefined, `more-info` will be used. |
-| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `toggle` will be used. |
+| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `none` will be used. |
 | `hold_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon hold, if undefined, `more-info` will be used. |
 | `card_layout` | string | Optional | `normal` (default), `large`, `large-2-rows` | Styling layout of the card, see [card layouts](#card-layouts) |
 | `columns` | string | Optional | `1`, `2`, `3` or `4` (default) | Number of columns when placed in a **section view** (e.g. `2` is 2/4) |
@@ -678,7 +678,7 @@ This card allows you to control your `cover` entities.
 | `stop_service` | string | Optional | Any service or script | A service to stop your cover, default to `cover.stop_cover` |
 | `close_service` | string | Optional | Any service or script | A service to close your cover, default to `cover.close_cover` |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon click, if undefined, `more-info` will be used. |
-| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `toggle` will be used. |
+| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `none` will be used. |
 | `hold_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon hold, if undefined, `more-info` will be used. |
 | `card_layout` | string | Optional | `normal` (default), `large`, `large-2-rows` | Styling layout of the card, see [card layouts](#card-layouts) |
 | `columns` | string | Optional | `1`, `2`, `3` or `4` (default) | Number of columns when placed in a **section view** (e.g. `2` is 2/4) |
@@ -758,7 +758,7 @@ This card allows you to add a dropdown menu for your `input_select` / `select` e
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `scrolling_effect` | boolean | Optional | `true` (default) or `false` | Allow text to scroll when the content exceeds the size of their container |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon click, if undefined, `more-info` will be used. |
-| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `toggle` will be used. |
+| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon double click, if undefined, `none` will be used. |
 | `hold_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on icon hold, if undefined, `more-info` will be used. |
 | `card_layout` | string | Optional | `normal` (default), `large`, `large-2-rows` | Styling layout of the card, see [card layouts](#card-layouts) |
 | `columns` | string | Optional | `1`, `2`, `3` or `4` (default) | Number of columns when placed in a **section view** (e.g. `2` is 2/4) |
@@ -842,7 +842,7 @@ This card allows you to control your `climate` entities.
 | `hide_target_temp_high` | boolean | Optional (only for entities supporting `target_temp_high`)| `true` or `false` (default) | Hides the high target temperature control if supported by the `entity`.                                         |
 | `state_color`           | boolean | Optional                            | `true` or `false` (default)                     | Applies a constant background color when the climate entity is ON.                                              |
 | `tap_action`            | object  | Optional                            | See [actions](#tap-double-tap-and-hold-actions) | Define the action triggered on tap. If not defined, `more-info` will be used.                                   |
-| `double_tap_action`     | object  | Optional                            | See [actions](#tap-double-tap-and-hold-actions) | Define the action triggered on double tap. If not defined, `toggle` will be used.                               |
+| `double_tap_action`     | object  | Optional                            | See [actions](#tap-double-tap-and-hold-actions) | Define the action triggered on double tap. If not defined, `none` will be used.                               |
 | `hold_action`           | object  | Optional                            | See [actions](#tap-double-tap-and-hold-actions) | Define the action triggered on hold. If not defined, `more-info` will be used.                                  |
 | `card_layout`           | string  | Optional                            | `normal` (default), `large`, `large-2-rows`     | Defines the styling layout of the card. See [card layouts](#card-layouts).                                      |
 | `columns`               | string  | Optional                            | `1`, `2`, `3`, or `4` (default)                 | Number of columns when placed in a **section view**.                                                            |
@@ -1018,7 +1018,7 @@ In every card that supports that option, you can add sub-buttons to customize yo
 | `show_attribute` | boolean | Optional | `true` or `false` (default) | Show an attribute of your `entity` below its `name` |
 | `attribute` | string | Optional (required if `show_attribute` is set to `true`) | An attribute from your `entity` | The attribute to show (e.g. `brightness`) |
 | `tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on sub-button click, if undefined, `more-info` will be used. |
-| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on sub-button double click, if undefined, `toggle` will be used. |
+| `double_tap_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on sub-button double click, if undefined, `none` will be used. |
 | `hold_action` | object | Optional | See [actions](#tap-double-tap-and-hold-actions) | Define the type of action on sub-button hold, if undefined, `more-info` will be used. |
 
 </details>
@@ -1297,6 +1297,9 @@ grid_options:
 ## Tap, double tap and hold actions
 
 You can also use Home Assistant default tap actions, double tap actions and hold actions on the cards that supports this option. For example, this allows you to display the “more info” window by holding a button icon or running a service when a sub-button is pressed.
+
+**Note: When a `double_tap_action` is configured, the regular `tap_action` will have a delay of 200ms to allow detection
+of a double tap. If this delay is undesirable, set `double_tap_action` to `none` to disable double tap handling.**
 
 ### Action options
 

--- a/src/bubble-card.js
+++ b/src/bubble-card.js
@@ -170,7 +170,7 @@ class BubbleCard extends HTMLElement {
                 action: "more-info"
             };
             enhancedConfig.double_tap_action = enhancedConfig.double_tap_action ?? {
-                action: buttonType === "state" ? "more-info" : "toggle"
+                action: "none"
             }
             enhancedConfig.hold_action = enhancedConfig.hold_action ?? {
                 action: buttonType === "state" ? "more-info" : "toggle"

--- a/src/cards/button/create.js
+++ b/src/cards/button/create.js
@@ -22,7 +22,7 @@ export function createStructure(context, appendTo = context.container) {
         icon: true,
         button: {
             tap_action: { action: "toggle" },
-            double_tap_action: { action: "toggle" },
+            double_tap_action: { action: "none" },
             hold_action: { action: "more-info" }
         }
     };
@@ -30,12 +30,12 @@ export function createStructure(context, appendTo = context.container) {
     actions['state'] = {
         icon: {
             tap_action: { action: "more-info" },
-            double_tap_action: { action: "more-info" },
+            double_tap_action: { action: "none" },
             hold_action: { action: "more-info" }
         },
         button: {
             tap_action: { action: "more-info" },
-            double_tap_action: { action: "more-info" },
+            double_tap_action: { action: "none" },
             hold_action: { action: "more-info" }
         }
     };

--- a/src/cards/button/editor.js
+++ b/src/cards/button/editor.js
@@ -193,7 +193,7 @@ export function renderButtonEditor(editor){
                 </h4>
                 <div class="content">
                     ${editor.makeActionPanel("Tap action", button_action, editor._config.button_type !== 'name' ? (editor._config.button_type === 'state' ? 'more-info' : (editor._config.button_type === 'slider' ? (isEntityType(editor, "sensor", editor._config.entity) ? 'more-info' : 'toggle') : 'toggle')) : 'none', 'button_action')}
-                    ${editor.makeActionPanel("Double tap action", button_action, editor._config.button_type !== 'name' ? (editor._config.button_type === 'state' ? 'more-info' : (editor._config.button_type === 'slider' ? 'none' : 'toggle')) : 'none', 'button_action')}
+                    ${editor.makeActionPanel("Double tap action", button_action, 'none', 'button_action')}
                     ${editor._config.button_type !== 'slider' ? editor.makeActionPanel("Hold action", button_action, editor._config.button_type !== 'name' ? (editor._config.button_type === 'slider' ? 'none' : 'more-info') : 'none', 'button_action') : ''}
                 </div>
             </ha-expansion-panel>

--- a/src/cards/climate/editor.js
+++ b/src/cards/climate/editor.js
@@ -155,7 +155,7 @@ export function renderClimateEditor(editor){
                 </h4>
                 <div class="content">
                     ${editor.makeActionPanel("Tap action", button_action, 'more-info', 'button_action')}
-                    ${editor.makeActionPanel("Double tap action", button_action, 'toggle', 'button_action')}
+                    ${editor.makeActionPanel("Double tap action", button_action, 'none', 'button_action')}
                     ${editor.makeActionPanel("Hold action", button_action, 'toggle', 'button_action')}
                 </div>
             </ha-expansion-panel>

--- a/src/cards/cover/editor.js
+++ b/src/cards/cover/editor.js
@@ -79,7 +79,7 @@ export function renderCoverEditor(editor){
                 </h4>
                 <div class="content">
                     ${editor.makeActionPanel("Tap action", button_action, 'more-info', 'button_action')}
-                    ${editor.makeActionPanel("Double tap action", button_action, 'toggle', 'button_action')}
+                    ${editor.makeActionPanel("Double tap action", button_action, 'none', 'button_action')}
                     ${editor.makeActionPanel("Hold action", button_action, 'toggle', 'button_action')}
                 </div>
             </ha-expansion-panel>

--- a/src/cards/media-player/editor.js
+++ b/src/cards/media-player/editor.js
@@ -145,7 +145,7 @@ export function renderMediaPlayerEditor(editor){
                 </h4>
                 <div class="content">
                     ${editor.makeActionPanel("Tap action", button_action, 'more-info', 'button_action')}
-                    ${editor.makeActionPanel("Double tap action", button_action, 'toggle', 'button_action')}
+                    ${editor.makeActionPanel("Double tap action", button_action, 'none', 'button_action')}
                     ${editor.makeActionPanel("Hold action", button_action, 'toggle', 'button_action')}
                 </div>
             </ha-expansion-panel>

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -467,8 +467,8 @@ class BubbleCardEditor extends LitElement {
         if (!defaultAction) {
             defaultAction = isDefault && label === "Tap action" 
             ? this._config.button_type !== "name" ? "more-info" : "none"
-            : isDefault 
-            ? this._config.button_type !== "name" ? "toggle" : "none"
+            : isDefault
+            ? "none"
             : '';
         }
 

--- a/src/tools/tap-actions.js
+++ b/src/tools/tap-actions.js
@@ -109,7 +109,7 @@ export function addActions(element, config, defaultEntity, defaultActions) {
 
   element.dataset.entity = config?.entity || defaultEntity;
   element.dataset.tapAction = JSON.stringify(config?.tap_action || defaultActions?.tap_action || { action: "more-info" });
-  element.dataset.doubleTapAction = JSON.stringify(config?.double_tap_action || defaultActions?.double_tap_action || { action: "toggle" });
+  element.dataset.doubleTapAction = JSON.stringify(config?.double_tap_action || defaultActions?.double_tap_action || { action: "none" });
   element.dataset.holdAction = JSON.stringify(config?.hold_action || defaultActions?.hold_action || { action: "toggle" });
 
   const tapAction = JSON.parse(element.dataset.tapAction);
@@ -215,7 +215,7 @@ class ActionHandler {
 
 export function sendActionEvent(element, config, action) {
   const tapAction = config.tap_action || { action: "more-info" };
-  const doubleTapAction = config.double_tap_action || { action: "toggle" };
+  const doubleTapAction = config.double_tap_action || { action: "none" };
   const holdAction = config.hold_action || { action: "toggle" };
   const entity = config.entity || this.config?.entity;
 


### PR DESCRIPTION
The downside of having not `none` double tap action is that it adds a 200ms delay to any tap action, which is noticeable and quite annoying. Therefore, it seems that `none` is really the best default.

This PR can be merged after this one: https://github.com/Clooos/Bubble-Card/pull/1392