### PR TITLE
Treat 0 values as “off”

### DIFF
--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -130,11 +130,12 @@ export function isEntityType(context, entityType, entity = context.config.entity
 
 export function isStateOn(context, entity = context.config.entity) {
     const state = getState(context, entity).toLowerCase();
+    const isTemperature = getAttribute(context, "unit_of_measurement", entity)?.includes('°')
     const card = 
       context.config.card_type !== 'pop-up' ? 
         context.card : 
         context.elements.headerContainer;
-    const numericState = Number(state) || Number(state) === 0;
+    const numericState = Number(state);
     const activeStringStates = [
         'on', 
         'open', 
@@ -164,7 +165,7 @@ export function isStateOn(context, entity = context.config.entity) {
         'alarm'
     ];
 
-    if (activeStringStates.includes(state) || numericState) {
+    if (activeStringStates.includes(state) || numericState || isTemperature) {
         return true;
     }
 


### PR DESCRIPTION
Zero values meaning “off” is the current behavior of the latest release, and it is quite useful. For most units, 0 is indeed the absence of something.

In #1213, it was reported that temperatures are an exception to that. Indeed! However, the fix made it treat all numeric values as “on”, and that's not cool!

This commit reverts back the previous behavior, and adds a special case for temperatures. Now, all units should behave just fine!

Some examples with power (W):

![2025-04-12_00:51:35](https://github.com/user-attachments/assets/8b18cee5-dcde-4e25-bdd1-3ecd05805fd0)

![2025-04-12_00:52:56](https://github.com/user-attachments/assets/a3cfc567-10b0-498f-995b-fa49d76dad8f)

