### PR TITLE
Make throttle function reliable

### DIFF
--- a/src/components/slider/create.js
+++ b/src/components/slider/create.js
@@ -246,12 +246,12 @@ export function createSliderStructure(context, config = {}) {
       context._hass.callService('climate', 'turn_on', {
         entity_id: context.config.entity
       }).then(() => {
-        updateEntity(context, finalPercentage);
+        throttledUpdateEntity(context, finalPercentage);
       }).catch(error => {
         console.error('Error turning on climate entity:', error);
       });
     } else {
-      updateEntity(context, finalPercentage);
+      throttledUpdateEntity(context, finalPercentage);
     }
     
     forwardHaptic("selection");
@@ -310,6 +310,7 @@ export function createSliderStructure(context, config = {}) {
 
     setupRangeValueDisplay(rangedPercentage);
     updateValueDisplay(rangedPercentage);
+    throttledUpdateEntity(context, rangedPercentage);
 
     options.targetElement.classList.add('slider-appear-animation');
     forwardHaptic("selection");

--- a/src/components/slider/create.js
+++ b/src/components/slider/create.js
@@ -310,7 +310,9 @@ export function createSliderStructure(context, config = {}) {
 
     setupRangeValueDisplay(rangedPercentage);
     updateValueDisplay(rangedPercentage);
-    throttledUpdateEntity(context, rangedPercentage);
+    if (options.sliderLiveUpdate) {
+      throttledUpdateEntity(context, rangedPercentage);
+    }
 
     options.targetElement.classList.add('slider-appear-animation');
     forwardHaptic("selection");

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -334,14 +334,23 @@ export function setLayout(context) {
 }
 
 export function throttle(mainFunction, delay = 300) {
-    let timerFlag;
+    let throttleTimeout;
+    let lastAction = new Date(0);
+    let lastArgs;
 
     return (...args) => {
-        if (timerFlag === undefined) {
-            mainFunction(...args);
-            timerFlag = setTimeout(() => {
-                timerFlag = undefined;
-            }, delay);
+        lastArgs = args;
+        const sinceLastAction = Date.now() - lastAction;
+
+        if (sinceLastAction >= delay) {
+            lastAction = Date.now();
+            mainFunction(...lastArgs);
+        } else if (!throttleTimeout) {
+            throttleTimeout = setTimeout(() => {
+                throttleTimeout = undefined;
+                lastAction = Date.now();
+                mainFunction(...lastArgs);
+            }, delay - sinceLastAction);
         }
     };
 }


### PR DESCRIPTION
Ideal throttle function should:

1. React immediately to the first event
2. Process no more than 1 event within the time specified by the delay
3. Always process the last event

* Failing to do ① will result in no action for singular events – e.g.
  you try to change the light color by just clicking on the slider, but
  nothing happens if you keep holding without moving
* Failing to do ② will result in actions being fired too fast – e.g.
  you stopped moving the mouse and also released the mouse button, now
  the device will receive two different values at almost the same time
* Failing to do ③ will result in the value being stuck at some point
  during dragging, and not at the final point – e.g. you drag the mouse
  past the 100% and stop, the value won't end up at 100%

The goal of this commit was to fix ③, but ① and ② had to be covered
because the throttle function has to be used on tap and release actions.

## Reproducible bug related to ③

When stopping the cursor movement, the real value was always stuck at some past value (instead of firing the last update). This was most noticeable when moving the slider past 100% or past 0%:

![2025-04-14_03:24:25](https://github.com/user-attachments/assets/bf4cc12b-b99a-443d-b3ea-aab2ebc0fde2)

## Reproducible bug related to ①

Long taps on the slider were not treated as a value change.

![2025-04-14_03:25:16](https://github.com/user-attachments/assets/be5301c3-3c53-4aa2-808b-e9e5afb74cae)

## After this PR

Now the real value always follows what you see on the screen. If you press, it immediately changes to that value (even if no mouse movement is detected). When you stop moving, the value is set based on the last event correctly.

![2025-04-14_03:27:25](https://github.com/user-attachments/assets/02aa3e94-7b67-45ec-8ef9-080c44a196d4)