### PR TITLE
Fix `click` propagation

### DIFF
--- a/src/components/slider/create.js
+++ b/src/components/slider/create.js
@@ -331,6 +331,10 @@ export function createSliderStructure(context, config = {}) {
     options.targetElement.classList.add('is-dragging');
     options.targetElement.addEventListener('pointermove', onPointerMove);
     window.addEventListener('pointerup', onPointerUp);
+    window.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    }, { capture: true, once: true });
   }
 
   if (context.config.read_only_slider) return;


### PR DESCRIPTION
Without this, releasing the mouse click over other elements will trigger their click events, which can be disastrous. For example, when sliding a value to 0, it's typical to end up over the navigation drawer, meaning that the moment the user releases the click, they'll be sent to a completely different page.

This issue was generally not noticeable on mobile devices, but on desktop it was quite annoying.

## Bug examples:

![2025-04-14_04:43:45](https://github.com/user-attachments/assets/9366cdf2-1beb-4122-821b-858a34065fa6)


## Fixed:

![2025-04-14_04:37:57](https://github.com/user-attachments/assets/791d241e-0bee-4653-8989-1c85de26f2c4)
