### PR TITLE
Fix external slider updates

### DIFF
--- a/src/components/slider/changes.js
+++ b/src/components/slider/changes.js
@@ -77,7 +77,7 @@ function getCurrentValue(context, entity, entityType) {
   
   // Check for pending value and if it's still valid
   if (pendingValue) {
-    const lastChanged = new Date(currentState.last_changed).getTime();
+    const lastChanged = new Date(currentState.last_updated).getTime();
     if (lastChanged < pendingValue.timestamp) {
       return pendingValue.percentage;
     }


### PR DESCRIPTION
While I'm not following the logic in that code path, the idea seems to be that it should do an early return if the new value was not processed yet.

And all that is fine, except that it was using `last_changed` instead of `last_updated`. For lights, it means that it only reacted to lights being turned on or off, not when the brightness was changing.

Resolves #1367.