### PR TITLE
Add the config parameter to limit the number of events fetched in the calendar card

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ This card allows you to display your calendar entities. Its content is scrollabl
 
 | Name                | Type    | Requirement  | Supported options                               | Description                                                                             |
 |---------------------|---------|--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------|
-| `days`              | number  | Optional     | A number                                        | The maximum number of days to display in the calendar (default: 7)                      |
+| `days`              | number  | Optional     | Any number (minimum: 1)                        | Number of calendar days to fetch events for, from now until the end of the Nth day (default: 7) |
 | `entities`          | object  | **Required** | A calendar entity object (see below)            | The entity to control (e.g., `calendar.main_calendar`).                                 |
 | `entities.entity`   | string  | **Required** | A calendar entity                               | The calendar entity to display                                                          |
 | `entities.color`    | string  | Optional     | A color                                         | A custom color for the calendar chip. If not defined, an automatic color will be picked |

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ This card allows you to display your calendar entities. Its content is scrollabl
 
 | Name                | Type    | Requirement  | Supported options                               | Description                                                                             |
 |---------------------|---------|--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------|
-| `days`              | number  | Optional     | A number                                        | Max number of days to display in the calendar (default: 7)                              |
+| `days`              | number  | Optional     | A number                                        | The maximum number of days to display in the calendar (default: 7)                      |
 | `entities`          | object  | **Required** | A calendar entity object (see below)            | The entity to control (e.g., `calendar.main_calendar`).                                 |
 | `entities.entity`   | string  | **Required** | A calendar entity                               | The calendar entity to display                                                          |
 | `entities.color`    | string  | Optional     | A color                                         | A custom color for the calendar chip. If not defined, an automatic color will be picked |

--- a/README.md
+++ b/README.md
@@ -934,6 +934,7 @@ This card allows you to display your calendar entities. Its content is scrollabl
 
 | Name                | Type    | Requirement  | Supported options                               | Description                                                                             |
 |---------------------|---------|--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `days`              | number  | Optional     | A number                                        | Max number of days to display in the calendar (default: 7)                              |
 | `entities`          | object  | **Required** | A calendar entity object (see below)            | The entity to control (e.g., `calendar.main_calendar`).                                 |
 | `entities.entity`   | string  | **Required** | A calendar entity                               | The calendar entity to display                                                          |
 | `entities.color`    | string  | Optional     | A color                                         | A custom color for the calendar chip. If not defined, an automatic color will be picked |

--- a/src/cards/calendar/changes.js
+++ b/src/cards/calendar/changes.js
@@ -31,11 +31,17 @@ const getEventDateKey = (eventStart) => {
 };
 
 export async function changeEventList(context) {
-  const daysOfEvents = context.config.days ?? 7;
+  const daysOfEvents = Math.max(1, context.config.days ?? 7);
 
-  const start = new Date().toISOString();
-  const end = new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * daysOfEvents).toISOString();
-  const params = `start=${start}&end=${end}`;
+  const now = new Date();
+  const start = now.toISOString();
+
+  // End time: remaining hours today + (days-1) full 24-hour periods
+  const end = new Date(now);
+  end.setDate(end.getDate() + (daysOfEvents - 1));
+  end.setHours(23, 59, 59, 999);
+
+  const params = `start=${start}&end=${end.toISOString()}`;
 
   const promises = context.config.entities.map(async (entity) => {
     const url = `calendars/${entity.entity}?${params}`;

--- a/src/cards/calendar/editor.js
+++ b/src/cards/calendar/editor.js
@@ -41,6 +41,12 @@ export function renderCalendarEditor(editor){
                       .data=${editor._config}
                       .schema=${[
                         {
+                          name: 'days',
+                          label: t('editor.calendar.days'),
+                          title: t('editor.calendar.days'),
+                          selector: { number: { step: 1, min: 1, max: 7} },
+                        },
+                        {
                           name: 'limit',
                           label: t('editor.calendar.limit'),
                           title: t('editor.calendar.limit'),

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -9,6 +9,7 @@
     "calendar": {
       "entity": "Entität",
       "color": "Farbe",
+      "days": "Max Tage",
       "limit": "Anzeigelimit",
       "list_of_calendars": "Kalenderliste",
       "show_end": "Endzeitpunkt anzeigen",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -9,6 +9,7 @@
     "calendar": {
       "entity": "Entity",
       "color": "Color",
+      "days": "Max Days",
       "limit": "Limit",
       "list_of_calendars": "List of calendars",
       "show_end": "Show end time",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -9,6 +9,7 @@
     "calendar": {
       "entity": "Entité",
       "color": "Couleur",
+      "days": "Jours Max",
       "limit": "Limite",
       "list_of_calendars": "Liste des calendriers",
       "show_end": "Voir l'heure de fin",

--- a/src/translations/zh_cn.json
+++ b/src/translations/zh_cn.json
@@ -9,6 +9,7 @@
     "calendar": {
       "entity": "实体",
       "color": "颜色",
+      "days": "最大天数",
       "limit": "限制",
       "list_of_calendars": "日历列表",
       "show_end": "显示结束时间",


### PR DESCRIPTION
## Proposed change
This PR exposes the calendar days setting in the calendar card editor, allowing users to configure how many days of events to fetch. On calendars with many events, this improves performance if the number of days displayed is far fewer than 7.

This change also fixes the confusing date range logic. The current logic adds N days * 24hrs to now, which can result in events from more than N days.

Consider if it's currently midday on Monday, 2 days will fetch events up to midday on Wednesday, showing 3 days worth of events. The fixed logic fetches up to 2 calendar days of events, that is 11:59pm Tuesday.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (thank you!)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

```yaml
type: custom:bubble-card
card_type: calendar
entities:
  ...
...
days: 2
```

## Example printscreens/gif

Before , with days = 3
<img width="491" height="344" alt="before" src="https://github.com/user-attachments/assets/9d6fe487-e71c-40ac-bb02-31871b5737ff" />

After change, days = 3
<img width="487" height="353" alt="Screenshot 2025-08-25 at 4 24 14 PM" src="https://github.com/user-attachments/assets/f3eb9ae0-f03d-4159-a502-3374ff4dec74" />


New editor field
<img width="504" height="269" alt="Screenshot 2025-08-25 at 4 25 27 PM" src="https://github.com/user-attachments/assets/28fa465d-edff-4e73-b010-9c816f6e9382" />


## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.
Users can now configure this limit in the editor

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for readme.
