### PR TITLE
Fix sorting of calendar events to correctly handle all day and timed events

### DIFF
--- a/src/cards/calendar/changes.js
+++ b/src/cards/calendar/changes.js
@@ -2,7 +2,7 @@ import { createElement, setLayout, applyScrollingEffect } from "../../tools/util
 import { handleCustomStyles } from '../../tools/style-processor.js';
 import setupTranslation from "../../tools/localize.js";
 import { addActions } from "../../tools/tap-actions.js";
-import { hashCode, intToRGB, parseEventDateTime } from "./helpers.js";
+import { hashCode, intToRGB, parseEventDateTime, sortEvents } from "./helpers.js";
 
 function dateDiffInMinutes(a, b) {
   const MS_PER_MINUTES = 1000 * 60;
@@ -41,22 +41,7 @@ export async function changeEventList(context) {
   const events = await Promise.all(promises);
 
   context.events = events.flat()
-    .sort((a, b) => {
-      const dateA = parseEventDateTime(a.start);
-      const dateB = parseEventDateTime(b.start);
-
-      const isAllDayA = a.start.date !== undefined;
-      const isAllDayB = b.start.date !== undefined;
-
-      if (isAllDayA && !isAllDayB) {
-        return -1;
-      }
-      if (!isAllDayA && isAllDayB) {
-        return 1;
-      }
-
-      return dateA.getTime() - dateB.getTime();
-    })
+    .sort(sortEvents)
     .slice(0, context.config.limit ?? undefined);
 }
 

--- a/src/cards/calendar/helpers.js
+++ b/src/cards/calendar/helpers.js
@@ -22,3 +22,40 @@ export function parseEventDateTime(event) {
 
   return new Date(event.dateTime);
 }
+
+export function sortEvents(a, b) {
+  const dateA = parseEventDateTime(a.start);
+  const dateB = parseEventDateTime(b.start);
+
+  // First, compare dates (year, month, day only - ignore time)
+  const dayA = new Date(dateA.getFullYear(), dateA.getMonth(), dateA.getDate());
+  const dayB = new Date(dateB.getFullYear(), dateB.getMonth(), dateB.getDate());
+
+  const dateDiff = dayA.getTime() - dayB.getTime();
+
+  // If events are on different dates, sort by date
+  if (dateDiff !== 0) {
+    return dateDiff;
+  }
+
+  // Events are on the same date - now sort by all-day vs timed
+  const isAllDayA = a.start.date !== undefined;
+  const isAllDayB = b.start.date !== undefined;
+
+  // Within the same date: all-day events come first
+  if (isAllDayA && !isAllDayB) {
+    return -1;  // All-day A comes before timed B
+  }
+  if (!isAllDayA && isAllDayB) {
+    return 1;   // Timed A comes after all-day B
+  }
+
+  // Both are same type (both all-day or both timed)
+  // For timed events, sort by actual time
+  if (!isAllDayA && !isAllDayB) {
+    return dateA.getTime() - dateB.getTime();
+  }
+
+  // Both are all-day events on same date - maintain original order
+  return 0;
+}

--- a/src/cards/calendar/helpers.test.js
+++ b/src/cards/calendar/helpers.test.js
@@ -1,0 +1,204 @@
+import { describe, test, expect } from '@jest/globals';
+import { parseEventDateTime, sortEvents } from './helpers.js';
+
+describe('parseEventDateTime', () => {
+  test('should parse all-day event with date property', () => {
+    const event = {
+      date: '2024-12-25'
+    };
+    
+    const result = parseEventDateTime(event);
+    
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(11); // December is month 11 (0-indexed)
+    expect(result.getDate()).toBe(25);
+  });
+
+  test('should parse timed event with dateTime property', () => {
+    const event = {
+      dateTime: '2024-12-25T14:30:00'
+    };
+    
+    const result = parseEventDateTime(event);
+    
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getFullYear()).toBe(2024);
+    expect(result.getMonth()).toBe(11);
+    expect(result.getDate()).toBe(25);
+    expect(result.getHours()).toBe(14);
+    expect(result.getMinutes()).toBe(30);
+  });
+});
+
+describe('sortEvents', () => {
+  describe('events on different dates', () => {
+    test('should sort events chronologically by date', () => {
+      const laterEvent = { start: { dateTime: '2024-12-26T10:00:00' } };
+      const earlierEvent = { start: { dateTime: '2024-12-25T10:00:00' } };
+      
+      const events = [laterEvent, earlierEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([earlierEvent, laterEvent]);
+    });
+
+    test('should sort all-day events on different dates chronologically', () => {
+      const laterEvent = { start: { date: '2024-12-26' } };
+      const earlierEvent = { start: { date: '2024-12-25' } };
+      
+      const events = [laterEvent, earlierEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([earlierEvent, laterEvent]);
+    });
+
+    test('should sort mixed event types on different dates chronologically', () => {
+      const laterAllDay = { start: { date: '2024-12-26' } };
+      const earlierTimed = { start: { dateTime: '2024-12-25T23:59:00' } };
+      
+      const events = [laterAllDay, earlierTimed];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([earlierTimed, laterAllDay]);
+    });
+  });
+
+  describe('events on the same date', () => {
+    test('should place all-day events before timed events', () => {
+      const allDayEvent = { start: { date: '2024-12-25' } };
+      const timedEvent = { start: { dateTime: '2024-12-25T10:00:00' } };
+      
+      const events = [timedEvent, allDayEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([allDayEvent, timedEvent]);
+    });
+
+    test('should place all-day events before early morning timed events', () => {
+      const allDayEvent = { start: { date: '2024-12-25' } };
+      const earlyMorningEvent = { start: { dateTime: '2024-12-25T00:01:00' } };
+      
+      const events = [earlyMorningEvent, allDayEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([allDayEvent, earlyMorningEvent]);
+    });
+
+    test('should place all-day events before late night timed events', () => {
+      const allDayEvent = { start: { date: '2024-12-25' } };
+      const lateNightEvent = { start: { dateTime: '2024-12-25T23:59:00' } };
+      
+      const events = [lateNightEvent, allDayEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([allDayEvent, lateNightEvent]);
+    });
+  });
+
+  describe('timed events on the same date', () => {
+    test('should sort timed events by time on same date', () => {
+      const earlyEvent = { start: { dateTime: '2024-12-25T09:00:00' } };
+      const lateEvent = { start: { dateTime: '2024-12-25T15:00:00' } };
+      
+      const events = [lateEvent, earlyEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([earlyEvent, lateEvent]);
+    });
+
+    test('should sort events with different times correctly', () => {
+      const midnight = { start: { dateTime: '2024-12-25T00:00:00' } };
+      const noon = { start: { dateTime: '2024-12-25T12:00:00' } };
+      const almostMidnight = { start: { dateTime: '2024-12-25T23:59:59' } };
+      
+      const events = [almostMidnight, noon, midnight];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([midnight, noon, almostMidnight]);
+    });
+
+    test('should handle events with same time', () => {
+      const event1 = { start: { dateTime: '2024-12-25T10:00:00' } };
+      const event2 = { start: { dateTime: '2024-12-25T10:00:00' } };
+      
+      const events = [event1, event2];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([event1, event2]);
+    });
+  });
+
+  describe('all-day events on the same date', () => {
+    test('should maintain stable order for multiple all-day events on same date', () => {
+      const allDay1 = { start: { date: '2024-12-25' } };
+      const allDay2 = { start: { date: '2024-12-25' } };
+      
+      const events = [allDay1, allDay2];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([allDay1, allDay2]);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should handle events across year boundary', () => {
+      const newYearEvent = { start: { dateTime: '2025-01-01T00:00:00' } };
+      const newYearEveEvent = { start: { dateTime: '2024-12-31T23:59:00' } };
+      
+      const events = [newYearEvent, newYearEveEvent];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([newYearEveEvent, newYearEvent]);
+    });
+
+    test('should handle events across month boundary', () => {
+      const firstOfMonth = { start: { date: '2024-12-01' } };
+      const lastOfPreviousMonth = { start: { date: '2024-11-30' } };
+      
+      const events = [firstOfMonth, lastOfPreviousMonth];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([lastOfPreviousMonth, firstOfMonth]);
+    });
+
+    test('should handle leap year dates', () => {
+      const leapDay = { start: { date: '2024-02-29' } };
+      const dayBefore = { start: { date: '2024-02-28' } };
+      const dayAfter = { start: { date: '2024-03-01' } };
+      
+      const events = [dayAfter, leapDay, dayBefore];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([dayBefore, leapDay, dayAfter]);
+    });
+  });
+
+  describe('realistic scenarios', () => {
+    test('should correctly order a mixed list of events', () => {
+      const christmasEve = { start: { dateTime: '2024-12-24T20:00:00' }, summary: 'Christmas Eve dinner' };
+      const christmasDay = { start: { date: '2024-12-25' }, summary: 'Christmas Day' };
+      const morningCoffee = { start: { dateTime: '2024-12-25T09:00:00' }, summary: 'Morning coffee' };
+      const afternoonMeeting = { start: { dateTime: '2024-12-25T15:00:00' }, summary: 'Afternoon meeting' };
+      const boxingDay = { start: { date: '2024-12-26' }, summary: 'Boxing Day' };
+      
+      const events = [afternoonMeeting, christmasDay, morningCoffee, boxingDay, christmasEve];
+      events.sort(sortEvents);
+      
+      expect(events).toEqual([christmasEve, christmasDay, morningCoffee, afternoonMeeting, boxingDay]);
+    });
+
+    test('should handle multiple all-day and timed events on same date', () => {
+      const lunch = { start: { dateTime: '2024-12-25T14:00:00' }, summary: 'Lunch' };
+      const holiday1 = { start: { date: '2024-12-25' }, summary: 'Holiday 1' };
+      const breakfast = { start: { dateTime: '2024-12-25T10:00:00' }, summary: 'Breakfast' };
+      const holiday2 = { start: { date: '2024-12-25' }, summary: 'Holiday 2' };
+      const dinner = { start: { dateTime: '2024-12-25T18:00:00' }, summary: 'Dinner' };
+      
+      const events = [lunch, holiday1, breakfast, holiday2, dinner];
+      events.sort(sortEvents);
+
+      expect(events).toEqual([holiday1, holiday2, breakfast, lunch, dinner]);
+    });
+  });
+});


### PR DESCRIPTION
## Breaking change
This changes the order in which events are sorted. Some users may have been accustomed to the incorrect sorting! 

## Proposed change
Refactors event sorting logic to properly handle all-day and timed events on the same date.

Previously all day events would be at the top of the list, regardless of which day they occur. This now correctly puts all day events in the correct order with timed events from previous days. 


## Type of change
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
No config changes

## Example printscreens/gif


## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.


## Checklist
- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->
