### PR TITLE
Add custom active state expression for button cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ This card is very versatile. It can be used as a **switch**, a **slider**, a **s
 | `name` | string | Optional | Any string | A name for your button, if not defined it will display the entity name |
 | `icon` | string | Optional | Any `mdi:` icon | An icon for your button, if not defined it will display the entity icon or the `entity-picture` |
 | `force_icon` | boolean | Optional | `true` or `false` (default) | Give the priority to the icon instead of the `entity-picture` |
+| `active` | string | Optional | JavaScript expression | Override the default active/on state logic with a custom expression (e.g., `hass.states['sensor.temperature'].state > 20`). The expression has access to `hass`, `entity`, and `state` variables |
 | `use_accent_color` | boolean | Optional (`false` default) | **For lights only.** Use the theme's accent color instead of the light's color.                         |
 | `show_state` | boolean | Optional | `true` or `false` (default) | Show or hide the state of your `entity` |
 | `show_name` | boolean | Optional | `true` (default) or `false` | Show or hide the name |
@@ -530,6 +531,39 @@ sub_button:
     show_background: false
     show_name: false
 ```
+
+</details>
+
+<details>
+
+<summary>A button with custom active state based on a condition</summary>
+
+<br>
+
+```yaml
+type: custom:bubble-card
+card_type: button
+entity: climate.thermostat
+button_type: switch
+name: Heating
+active: hass.states['sensor.temperature'].state < 18
+```
+
+This button will show as active (highlighted) when the temperature drops below 18°C, providing a visual indicator that heating is needed. Another example could be a washing machine button that highlights when the power consumption indicates it's running:
+
+```yaml
+type: custom:bubble-card
+card_type: button
+entity: switch.washing_machine
+button_type: switch
+name: Washing Machine
+active: hass.states['sensor.washing_machine_power'].state > 10
+```
+
+You can use any JavaScript expression that evaluates to a boolean. The expression has access to:
+- `hass`: The Home Assistant state object (access any entity via `hass.states['entity_id']`)
+- `entity`: The current entity ID (the button's `entity` property)
+- `state`: The current state of the button's entity
 
 </details>
 

--- a/src/cards/button/changes.js
+++ b/src/cards/button/changes.js
@@ -1,5 +1,5 @@
-import { getButtonType } from "./helpers.js";
-import { 
+import { getButtonType, evaluateActiveState } from "./helpers.js";
+import {
   getState,
   isStateOn,
   isStateRequiringAttention,
@@ -14,7 +14,8 @@ export function changeButton(context) {
   const cardType = context.config.card_type;
   const buttonType = getButtonType(context);
   const isLight = isEntityType(context, "light");
-  const isOn = isStateOn(context);
+  const customActive = evaluateActiveState(context);
+  const isOn = customActive !== null ? customActive : isStateOn(context);
   const requiresAttention = isStateRequiringAttention(context);
   const lightColor = getIconColor(context);
 

--- a/src/cards/button/editor.js
+++ b/src/cards/button/editor.js
@@ -63,7 +63,7 @@ export function renderButtonEditor(editor){
                 <ha-icon icon="mdi:cog"></ha-icon>
                 ${isPopUp ? 'Header card settings' : 'Card settings'}
                 </h4>
-                <div class="content">     
+                <div class="content">
                     <ha-textfield
                         label="Optional - Name"
                         .value="${editor._config?.name || ''}"
@@ -72,6 +72,13 @@ export function renderButtonEditor(editor){
                     ></ha-textfield>
                     ${editor.makeDropdown("Optional - Icon", "icon")}
                     ${editor.makeShowState()}
+                    <ha-textfield
+                        label="Optional - Active state expression"
+                        .value="${editor._config?.active || ''}"
+                        .configValue="${"active"}"
+                        @input="${editor._valueChanged}"
+                        placeholder="hass.states['entity_id'].state === 'value'"
+                    ></ha-textfield>
                 </div>
             </ha-expansion-panel>
             ${makeButtonSliderPanel(editor)}

--- a/src/cards/button/helpers.js
+++ b/src/cards/button/helpers.js
@@ -1,4 +1,6 @@
-import { isEntityType, getAttribute } from "../../tools/utils.js";
+import { isEntityType, getAttribute, getState } from "../../tools/utils.js";
+
+const compiledActiveCache = new Map();
 
 export function getButtonType(context) {
   let buttonType = context.config.button_type;
@@ -17,8 +19,41 @@ export function getButtonType(context) {
 
 export function readOnlySlider(context) {
   const entity = context.config.entity;
-  const readOnlySlider = 
+  const readOnlySlider =
     isEntityType(context, "sensor", entity) && getAttribute(context, "unit_of_measurement", entity) === "%";
 
   return readOnlySlider;
+}
+
+export function evaluateActiveState(context) {
+  if (!context.config.active) {
+    return null;
+  }
+
+  try {
+    let compiledFunction = compiledActiveCache.get(context.config.active);
+    if (!compiledFunction) {
+      compiledFunction = Function(
+        "hass",
+        "entity",
+        "state",
+        `return ${context.config.active};`
+      );
+      compiledActiveCache.set(context.config.active, compiledFunction);
+      if (compiledActiveCache.size > 100) {
+        const oldestKey = compiledActiveCache.keys().next().value;
+        compiledActiveCache.delete(oldestKey);
+      }
+    }
+
+    const result = compiledFunction(
+      context._hass,
+      context.config.entity,
+      getState(context)
+    );
+    return Boolean(result);
+  } catch (error) {
+    console.error('Error evaluating active expression:', error);
+    return null;
+  }
 }


### PR DESCRIPTION
## Description

This PR adds the ability to override the default active/on state logic for button cards with a custom JavaScript expression, providing more flexibility in controlling when a button appears active/highlighted.

Fixes #1953

## Changes

- **Added `evaluateActiveState()` helper function** in `src/cards/button/helpers.js`
  - Evaluates custom JavaScript expressions with caching for performance
  - Safe boolean conversion of results
  - Proper error handling
  
- **Modified `changeButton()` function** in `src/cards/button/changes.js`
  - Checks for custom active state first, falls back to default `isStateOn()` behavior
  - Maintains backward compatibility

- **Added UI field** in `src/cards/button/editor.js`
  - Text input for active expression in the Card settings panel
  - Helpful placeholder showing expected format

- **Updated documentation** in `README.md`
  - Added `active` option to the button options table
  - Included practical examples (thermostat, washing machine)

## Features

- Expression has access to `hass`, `entity`, and `state` variables
- Results are cached for performance (similar to styles evaluation)
- Falls back to default behavior when not configured
- Works with all button types
- No breaking changes

## Example Use Cases

**Thermostat button that shows active when heating is needed:**
```yaml
type: custom:bubble-card
card_type: button
entity: climate.thermostat
button_type: switch
name: Heating
active: hass.states['sensor.temperature'].state < 18
```

**Appliance button that highlights based on power consumption:**
```yaml
type: custom:bubble-card
card_type: button
entity: switch.washing_machine
button_type: switch
name: Washing Machine
active: hass.states['sensor.washing_machine_power'].state > 10
```

## Testing

- Backward compatible: Existing cards without `active` config work as before
- Expression evaluation matches existing `evalStyles` pattern
- Boolean conversion ensures predictable behavior