### PR TITLE
Add note about editor schema "default" key

### DIFF
--- a/src/modules/editor-schema-docs.md
+++ b/src/modules/editor-schema-docs.md
@@ -202,7 +202,9 @@ Every field in your editor schema can have these common properties:
 | `label` | string | The displayed name for the field |
 | `required` | boolean | Whether the field is required |
 | `disabled` | boolean | Whether the field is disabled |
-| `default` | any | Default value if no value is provided |
+| `default` | any | Default value to show if no value is provided[^1] |
+
+[^1]: Note that this only communicates the default to the user, but the value provided here is not applied to the configuration.
 
 ## Field types
 


### PR DESCRIPTION
## Proposed change

This is a minor documentation change to emphasize that the `default` key in an editor schema is not actually applied to the configuration, but only serves to inform the user of the default.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

This PR is related to issue or discussion: #2051

## Checklist
- [ ] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.