### PR TITLE
fix: improve iOS touch handling for pop-up

### DIFF
--- a/src/cards/pop-up/backdrop.css
+++ b/src/cards/pop-up/backdrop.css
@@ -16,7 +16,7 @@
 
 .bubble-backdrop.is-hidden {
   opacity: 0;
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
 .bubble-backdrop.has-blur {

--- a/src/cards/pop-up/styles.css
+++ b/src/cards/pop-up/styles.css
@@ -17,6 +17,7 @@
     -ms-overflow-style: none; /* for Internet Explorer, Edge */
     scrollbar-width: none; /* for Firefox */
     overflow: auto; 
+    -webkit-overflow-scrolling: touch; /* iOS momentum scrolling */
     grid-auto-rows: min-content;
     padding: 18px 18px calc(140px + var(--custom-height-offset-mobile)) 18px;
     mask-image: linear-gradient(to bottom, transparent 0px, black 24px, black calc(100% - 40px), transparent 100%);


### PR DESCRIPTION
Fixes #2246

This PR improves iOS touch handling for the pop-up component:

- Add  for proper iOS momentum scrolling
- Add  to backdrop hidden state to ensure iOS properly ignores the backdrop element when hidden

These changes should fix the issue where pop-ups appear "grayed out" and buttons cannot be pressed on iOS devices running the Home Assistant App.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*