### PR TITLE
UI/UX: Whole-page opacity hide creates blank screen with no accessible loading state

### DIFF
--- a/src/bubble-pop-up-fix.js
+++ b/src/bubble-pop-up-fix.js
@@ -1,24 +1,56 @@
 function hideElementsUntilBubbleCard() {
-    const selector = "body";
-    const root = document.querySelector(selector);
+    const root = document.body || document.querySelector("body");
+
+    if (!root) {
+        return;
+    }
+
+    const loadingOverlay = document.createElement("div");
+    loadingOverlay.setAttribute("role", "status");
+    loadingOverlay.setAttribute("aria-live", "polite");
+    loadingOverlay.setAttribute("aria-atomic", "true");
+    loadingOverlay.textContent = "Loading Bubble Card…";
+    loadingOverlay.style.position = "fixed";
+    loadingOverlay.style.top = "16px";
+    loadingOverlay.style.right = "16px";
+    loadingOverlay.style.zIndex = "2147483647";
+    loadingOverlay.style.padding = "8px 12px";
+    loadingOverlay.style.borderRadius = "8px";
+    loadingOverlay.style.backgroundColor = "rgba(17, 24, 39, 0.9)";
+    loadingOverlay.style.color = "#fff";
+    loadingOverlay.style.fontFamily = "DejaVu Sans,Verdana,Geneva,sans-serif";
+    loadingOverlay.style.fontSize = "14px";
+
+    root.setAttribute("aria-busy", "true");
+    root.appendChild(loadingOverlay);
+
+    const clearLoadingState = function() {
+        if (loadingOverlay.parentNode) {
+            loadingOverlay.parentNode.removeChild(loadingOverlay);
+        }
+
+        root.removeAttribute("aria-busy");
+    };
+
     let bubbleCard = customElements.get("bubble-card");
+
+    if (bubbleCard) {
+        clearLoadingState();
+        return;
+    }
 
     const intervalId = setInterval(function() {
         bubbleCard = customElements.get("bubble-card");
 
         if (bubbleCard) {
             clearInterval(intervalId);
-            root.style.transition = "opacity 0.5s";
-            root.style.opacity = "1";
-        } else {
-            root.style.opacity = "0";
+            clearLoadingState();
         }
-    }, 0);
+    }, 50);
 
     setTimeout(function() {
         clearInterval(intervalId);
-        root.style.transition = "opacity 0.5s";
-        root.style.opacity = "1";
+        clearLoadingState();
     }, 1500);
 }
 


### PR DESCRIPTION
## 🎨 UI/UX Improvement

### Problem
The script hides the entire `<body>` (`opacity = "0"`) until `bubble-card` is registered. This produces a full blank screen (no skeleton/loading UI), which looks like a freeze on slow devices. It also lacks any `aria-busy`/status messaging, so assistive technology users get no loading feedback while visual users see nothing.


**Severity**: `high`
**File**: `src/bubble-pop-up-fix.js`

### Solution
Replace full-page hiding with an explicit loading overlay and accessibility state. Example: create a small overlay element (`role="status"`, `aria-live="polite"`, text like "Loading Bubble Card…"), set `document.body.setAttribute("aria-busy", "true")` while waiting, and remove overlay + clear `aria-busy` once `customElements.get("bubble-card")` is available. Do not set `body.style.opacity = "0"`.


### Changes
- `src/bubble-pop-up-fix.js` (modified)


## Breaking change



## Proposed change



## Type of change


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration


```yaml

```

## Example printscreens/gif



## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.



## Checklist


- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.




Closes #2308