### PR TITLE
Added swing_horizontal_mode functionality for climate card sub-buttons

### DIFF
--- a/src/components/dropdown/helpers.js
+++ b/src/components/dropdown/helpers.js
@@ -25,6 +25,8 @@ export function getTranslatedAttribute(context, state, attribute, option) {
             return context._hass.formatEntityState(state, option);
         case 'swing_modes':
             return context._hass.formatEntityAttributeValue(state, "swing_mode", option);
+        case 'swing_horizontal_modes':
+            return context._hass.formatEntityAttributeValue(state, "swing_horizontal_mode", option);
         case 'preset_modes':
             return context._hass.formatEntityAttributeValue(state, "preset_mode", option);
         default:
@@ -38,6 +40,8 @@ export function getSelectedAttribute(state, attribute) {
             return state.attributes.fan_mode || null;
         case 'swing_modes':
             return state.attributes.swing_mode || null;
+        case 'swing_horizontal_modes':
+            return state.attributes.swing_horizontal_mode || null;
         case 'preset_modes':
             return state.attributes.preset_mode || null;
         case 'effect_list':
@@ -98,6 +102,14 @@ export function getOptionIcon(context, state, attribute, option) {
             icon.hass = context._hass;
             icon.stateObj = state;
             break;
+        case 'swing_horizontal_modes':
+            icon = document.createElement('ha-attribute-icon');
+            icon.slot = 'graphic';
+            icon.attribute = 'swing_horizontal_mode';
+            icon.attributeValue = option;
+            icon.hass = context._hass;
+            icon.stateObj = state;
+            break;
         case 'preset_modes':
             icon = document.createElement('ha-attribute-icon');
             icon.slot = 'graphic';
@@ -149,6 +161,12 @@ export function callSelectService(context, entity, selectedOption, config) {
                     context._hass.callService('climate', 'set_swing_mode', {
                         entity_id: entity,
                         swing_mode: selectedOption
+                    });
+                    break;
+                case 'swing_horizontal_modes':
+                    context._hass.callService('climate', 'set_swing_horizontal_mode', {
+                        entity_id: entity,
+                        swing_horizontal_mode: selectedOption
                     });
                     break;
                 case 'preset_modes':

--- a/src/editor/bubble-card-editor.js
+++ b/src/editor/bubble-card-editor.js
@@ -218,6 +218,7 @@ class BubbleCardEditor extends LitElement {
             'hvac_modes',
             'fan_modes',
             'swing_modes',
+            'swing_horizontal_modes',
             'preset_modes',
             'effect_list'
         ];


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
Some air conditioner integrations (including the Custom [Gree Climate Intergration](https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent) I use) allow for granular control over both the vertical and horizontal swing modes.

The vertical swing mode utilizes the original `swing_mode` attribute, while the horizontal swing mode uses the newly added `swing_horizontal_mode` as documented [here](https://developers.home-assistant.io/docs/core/entity/climate/#:~:text=swing%20is%20implemented.-,swing_horizontal_mode,-str%20%7C%20None).

This PR focuses on adding the `swing_horizontal_modes` to the list of available sub-button selectable attributes for climate cards, while ensuring that a dropdown select performs the correct action: `set_swing_horizontal_mode`.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: custom:bubble-card
card_type: climate
sub_button:
  main:
    - name: "Horizontal Swing Mode"
      select_attribute: swing_horizontal_modes
      show_arrow: false
      sub_button_type: select
entity: climate.office_ac
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->
### Before the PR:
- Horizontal swing modes not a selectable attribute despite being part of the climate entity
<img width="445" height="514" alt="Screenshot 2026-04-08 at 1 42 11 AM" src="https://github.com/user-attachments/assets/59c78d4c-681d-4882-9984-c65d304c0688" />


### After the PR:
#### For climate entities WITH `swing_horizontal_mode`

- Horizontal swing mode selection for sub-buttons
<img width="441" height="548" alt="Screenshot 2026-04-08 at 1 27 15 AM" src="https://github.com/user-attachments/assets/3cab3765-1243-4a53-a12a-8851b8b20e80" />

- Auto-filled horizontal swing modes from attribute
<img width="383" height="413" alt="Screenshot 2026-04-08 at 1 27 54 AM" src="https://github.com/user-attachments/assets/f65a035e-2a4f-4c8d-bf40-2a638f888151" />

- Tip: using [Custom dropdown module](https://github.com/Clooos/Bubble-Card/discussions/1720) with custom icons 🤩
<img width="391" height="425" alt="Screenshot 2026-04-08 at 1 30 00 AM" src="https://github.com/user-attachments/assets/b22a64bb-4eff-4adc-a058-4adba0264926" />


#### For climate entities WITHOUT `swing_horizontal_mode`

- Horizontal swing mode does not show in the attributes dropdown selection
<img width="439" height="545" alt="Screenshot 2026-04-08 at 1 11 36 AM" src="https://github.com/user-attachments/assets/0a459803-36ef-4861-a340-5c8a40cf5991" />


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue or discussion: https://github.com/Clooos/Bubble-Card/discussions/1739

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->
No documentation update required.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->
