### PR TITLE
Security: Path traversal in YAML `!include` resolution

### DIFF
--- a/src/modules/yaml-schema.js
+++ b/src/modules/yaml-schema.js
@@ -4,7 +4,23 @@ const LEGACY_MODULES_BASE_PATH = '/local/bubble/';
 
 function sanitizeIncludePath(path) {
   if (!path || typeof path !== 'string') return '';
-  return path.trim().replace(/^\.\/+/, '').replace(/^\/+/, '');
+
+  const trimmedPath = path.trim();
+  if (!trimmedPath) return '';
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmedPath) || trimmedPath.startsWith('//')) return '';
+
+  let decodedPath = trimmedPath;
+  try {
+    decodedPath = decodeURIComponent(trimmedPath);
+  } catch (_error) {
+    return '';
+  }
+
+  const normalizedPath = decodedPath.replace(/^\.\/+/, '').replace(/^\/+/, '');
+  if (!normalizedPath || normalizedPath.includes('\\')) return '';
+  if (normalizedPath.split('/').some((segment) => segment === '..')) return '';
+
+  return normalizedPath;
 }
 
 function fetchIncludeContent(relativePath) {
@@ -16,8 +32,16 @@ function fetchIncludeContent(relativePath) {
   const sanitizedPath = sanitizeIncludePath(relativePath);
   if (!sanitizedPath) return null;
 
-  const url = `${LEGACY_MODULES_BASE_PATH}${sanitizedPath}`;
+  let url = '';
   try {
+    const baseUrl = new URL(LEGACY_MODULES_BASE_PATH, typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
+    const resolvedUrl = new URL(sanitizedPath, baseUrl);
+    if (!resolvedUrl.pathname.startsWith(baseUrl.pathname)) {
+      console.error(`Bubble Card - Unable to resolve !include (${relativePath}): Invalid include path.`);
+      return null;
+    }
+
+    url = `${resolvedUrl.pathname}${resolvedUrl.search}`;
     const request = new XMLHttpRequest();
     request.open('GET', url, false);
     request.send(null);


### PR DESCRIPTION
## Summary

Security: Path traversal in YAML `!include` resolution

## Problem

**Severity**: `High` | **File**: `src/modules/yaml-schema.js:L5`

The include-path sanitizer only trims leading `./` and `/`, but does not reject traversal segments like `../`. Because the final URL is built as `/local/bubble/${sanitizedPath}`, an attacker-controlled YAML include could escape the intended base directory and request other same-origin paths (depending on server path normalization), potentially exposing unintended files.

## Solution

Normalize and validate paths before fetching: reject `..`, backslashes, URL-encoded traversal, and absolute URLs. Resolve with `new URL(relativePath, LEGACY_MODULES_BASE_PATH)` and enforce that the resolved pathname starts with the expected base pathname.

## Changes

- `src/modules/yaml-schema.js` (modified)