### PR TITLE
Enhance README with sub-button styles example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2234,6 +2234,12 @@ This one is changing a button name/state with "It's currently sunny" depending o
 styles: |
   ${card.querySelector('.bubble-name').innerText = "It's currently " + hass.states['weather.home'].state}
 ```
+or when applied for sub-buttons:
+```yaml
+styles: |
+ ${card.querySelector('.bubble-sub-button-1 .bubble-sub-button-name-container').innerText = "It's currently " + hass.states['weather.home'].state}
+```
+
 
 If you want to template the state (`.bubble-state`) don't toggle `show_state: true` just toggle `show_attribute: true` without any attribute.
 


### PR DESCRIPTION
Setting the text for a subbutton is not that straightforward. Currently there is no example explaining how to do it.

This issue (and my own tinkering) explains that one could replace the selector with '.bubble-sub-button-1'.
This works, but also overwrites the icon, causing unexpected behaviour and confusion.

This PR proposes to add an additional example, specific for subbuttons so users understand they need to add .bubble-sub-button-name-container in the selector