### PR TITLE
Add bright-background class to sub-buttons so labels stay readable on light state colors

### DIFF
--- a/src/components/sub-button/utils.js
+++ b/src/components/sub-button/utils.js
@@ -1,4 +1,4 @@
-import { getAttribute, isStateOn, isStateRequiringAttention, formatDateTime, createElement, getStateSurfaceColor, getState, isTimerEntity, timerTimeRemaining, computeDisplayTimer, startElementTimerInterval, stopElementTimerInterval, formatNumericValue, getTemperatureUnit } from "../../tools/utils.js";
+import { getAttribute, isStateOn, isStateRequiringAttention, formatDateTime, createElement, getStateSurfaceColor, isColorLight, getState, isTimerEntity, timerTimeRemaining, computeDisplayTimer, startElementTimerInterval, stopElementTimerInterval, formatNumericValue, getTemperatureUnit } from "../../tools/utils.js";
 import { applyScrollingEffect } from "../../tools/text-scrolling.js";
 import { getIcon, getLightColorSignature, getImage } from "../../tools/icon.js";
 import { addActions, addFeedback } from "../../tools/tap-actions.js";
@@ -188,7 +188,7 @@ export function updateBackground(element, options) {
 
   if (!showBackground) {
     if (element.classList.contains('background-on') || element.classList.contains('background-off')) {
-      element.classList.remove('background-on', 'background-off');
+      element.classList.remove('background-on', 'background-off', 'bright-background');
     }
     if (element.style.getPropertyValue('--bubble-sub-button-light-background-color')) {
       element.style.removeProperty('--bubble-sub-button-light-background-color');
@@ -237,6 +237,9 @@ export function updateBackground(element, options) {
       element.style.setProperty('--bubble-sub-button-light-background-color', newColor);
     }
 
+    // Use dark text on bright state backgrounds so the label stays readable (#2450)
+    element.classList.toggle('bright-background', isColorLight(newColor, 0.5));
+
     if (!element.classList.contains('background-on')) {
       element.classList.add('background-on');
       element.classList.remove('background-off');
@@ -246,6 +249,7 @@ export function updateBackground(element, options) {
       element.classList.add('background-off');
       element.classList.remove('background-on');
     }
+    element.classList.remove('bright-background');
     if (element.style.getPropertyValue('--bubble-sub-button-light-background-color')) {
       element.style.removeProperty('--bubble-sub-button-light-background-color');
     }

--- a/src/components/sub-button/utils.test.js
+++ b/src/components/sub-button/utils.test.js
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// Controls the color returned by getStateSurfaceColor (via the mocked getIconColor).
+let mockIconColor = 'rgb(255, 230, 120)';
+
+// Mock the sibling modules that sub-button/utils.js (and the real tools/utils.js it
+// imports) depend on, so the module graph resolves without a DOM. tools/utils.js itself
+// is kept REAL, so the test exercises the real isColorLight + getStateSurfaceColor wiring.
+jest.unstable_mockModule('../../tools/icon.js', () => ({
+    getIcon: jest.fn(() => ''),
+    getImage: jest.fn(() => ''),
+    getLightColorSignature: jest.fn(() => 'sig'),
+    getIconColor: jest.fn(() => mockIconColor),
+}));
+
+jest.unstable_mockModule('../../tools/text-scrolling.js', () => ({
+    applyScrollingEffect: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../tools/tap-actions.js', () => ({
+    addActions: jest.fn(),
+    addFeedback: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../tools/validate-condition.js', () => ({
+    checkConditionsMet: jest.fn(() => true),
+    validateConditionalConfig: jest.fn(() => true),
+    ensureArray: jest.fn((value) => (Array.isArray(value) ? value : [value])),
+}));
+
+jest.unstable_mockModule('../../tools/style.js', () => ({
+    isColorCloseToWhite: jest.fn(() => false),
+}));
+
+jest.unstable_mockModule('../../components/base-card/index.js', () => ({
+    updateContentContainerFixedClass: jest.fn(),
+}));
+
+function createMockClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+    return {
+        add: (...names) => names.forEach((name) => classes.add(name)),
+        remove: (...names) => names.forEach((name) => classes.delete(name)),
+        contains: (name) => classes.has(name),
+        toggle: (name, force) => {
+            const shouldAdd = force === undefined ? !classes.has(name) : force;
+            if (shouldAdd) classes.add(name);
+            else classes.delete(name);
+            return classes.has(name);
+        },
+    };
+}
+
+function createMockStyle() {
+    const props = new Map();
+    return {
+        setProperty: (name, value) => props.set(name, value),
+        getPropertyValue: (name) => props.get(name) ?? '',
+        removeProperty: (name) => props.delete(name),
+    };
+}
+
+function createMockElement(initialClasses = []) {
+    return {
+        style: createMockStyle(),
+        classList: createMockClassList(initialClasses),
+    };
+}
+
+function createContext() {
+    return {
+        config: { card_type: 'button', button_type: 'default', entity: 'climate.test' },
+        card: { style: createMockStyle() },
+        popUp: { style: createMockStyle() },
+        _hass: { states: { 'climate.test': { state: 'heat', attributes: {} } } },
+    };
+}
+
+function createOptions(overrides = {}) {
+    const context = createContext();
+    return {
+        showBackground: true,
+        isOn: true,
+        stateBackground: true,
+        lightBackground: true,
+        entity: 'climate.test',
+        context,
+        state: context._hass.states['climate.test'],
+        ...overrides,
+    };
+}
+
+describe('updateBackground bright-background class', () => {
+    let updateBackground;
+
+    beforeEach(async () => {
+        jest.resetModules();
+        mockIconColor = 'rgb(255, 230, 120)';
+        ({ updateBackground } = await import('./utils.js'));
+    });
+
+    test('adds bright-background when the state background color is light', () => {
+        const element = createMockElement();
+        updateBackground(element, createOptions());
+
+        expect(element.classList.contains('background-on')).toBe(true);
+        expect(element.classList.contains('bright-background')).toBe(true);
+    });
+
+    test('does not add bright-background when the state background color is dark', () => {
+        mockIconColor = 'rgb(20, 20, 30)';
+        const element = createMockElement();
+        updateBackground(element, createOptions());
+
+        expect(element.classList.contains('background-on')).toBe(true);
+        expect(element.classList.contains('bright-background')).toBe(false);
+    });
+
+    test('removes a stale bright-background when the entity turns off', () => {
+        const element = createMockElement(['background-on', 'bright-background']);
+        updateBackground(element, createOptions({ isOn: false }));
+
+        expect(element.classList.contains('background-off')).toBe(true);
+        expect(element.classList.contains('bright-background')).toBe(false);
+    });
+
+    test('removes a stale bright-background when the background is hidden', () => {
+        const element = createMockElement(['background-on', 'bright-background']);
+        updateBackground(element, createOptions({ showBackground: false }));
+
+        expect(element.classList.contains('bright-background')).toBe(false);
+    });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

The sub-button styles already define a `.bright-background` rule that switches the label to dark text, but nothing ever added the class, so on bright state backgrounds the text stayed light and was hard to read (#2450).

`updateBackground()` now uses the existing `isColorLight()` helper to toggle `bright-background` based on the computed surface color, and clears the class again when the background is turned off or hidden so the dark text doesn't linger on the default dark background.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

No config change needed. Reproduces on any sub-button with a state background whose color is light, e.g.:

```yaml
type: custom:bubble-card
card_type: button
entity: light.kitchen
sub_button:
  - entity: light.kitchen
    show_background: true
    show_state: true
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->

Haven't attached a before/after yet, happy to add one if useful. The effect is that the sub-button label switches to dark text once the state background is light enough, instead of staying light-on-light.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2450
- This PR is related to issue or discussion:
- Link to documentation pull request:

Verified locally: the full Jest suite passes (18 suites / 231 tests), and I added a focused test for the new behaviour. Temporarily removing the toggle line makes that test fail, so it actually guards the fix.

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->

None, no user-facing config or behaviour to document beyond the readability fix.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->