### PR TITLE
Clear horizontal buttons stack highlight when closing a pop-up with the back button

### DIFF
--- a/src/cards/horizontal-buttons-stack/create.js
+++ b/src/cards/horizontal-buttons-stack/create.js
@@ -82,7 +82,9 @@ export function createButton(context, index) {
     }
 
     window.addEventListener('location-changed', handleUrlChange);
-    
+    window.addEventListener('popstate', handleUrlChange);
+    window.addEventListener('hashchange', handleUrlChange);
+
     context.elements.buttons.push(button);
 
     return button;

--- a/src/cards/horizontal-buttons-stack/create.test.js
+++ b/src/cards/horizontal-buttons-stack/create.test.js
@@ -131,4 +131,28 @@ describe('horizontal buttons stack navigation', () => {
         expect(navigate).toHaveBeenCalledWith(button, '/lovelace/');
         expect(addHash).not.toHaveBeenCalled();
     });
+
+    test('clears the highlight when the popup is closed with the browser back button', () => {
+        const context = buildContext('#kitchen');
+        context.config.highlight_current_view = true;
+        const button = createButton(context, 1);
+
+        const getHandler = (type) => global.window.addEventListener.mock.calls
+            .find(([eventType]) => eventType === type)?.[1];
+
+        const hashchangeHandler = getHandler('hashchange');
+        const popstateHandler = getHandler('popstate');
+        expect(hashchangeHandler).toBeDefined();
+        expect(popstateHandler).toBeDefined();
+
+        global.location.hash = '#kitchen';
+        getHandler('location-changed')();
+        expect(button.classList.contains('highlight')).toBe(true);
+
+        // Browser back/forward fires popstate/hashchange without location-changed
+        global.location.hash = '';
+        popstateHandler();
+        hashchangeHandler();
+        expect(button.classList.contains('highlight')).toBe(false);
+    });
 });


### PR DESCRIPTION
## Proposed change

Fixes #2074. When a pop-up opened from the horizontal buttons stack is closed with the browser back button, the previously active button stayed highlighted.

The highlight is recomputed in `handleUrlChange`, but that was only wired to the `location-changed` event. Closing a pop-up with the browser back/forward button fires `popstate`/`hashchange` instead of `location-changed`, so the highlight never got re-evaluated and stuck on the old view.

This adds `popstate` and `hashchange` listeners that call the same `handleUrlChange`, so the highlight clears correctly on back-button navigation.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Any horizontal buttons stack with `highlight_current_view` on and buttons that open pop-ups:

```yaml
type: custom:bubble-card
card_type: horizontal-buttons-stack
highlight_current_view: true
```

## Example printscreens/gif

I don't have a gif for this, but the repro is: open a pop-up from a highlighted button, then close it with the browser back button and the button stays highlighted. With this change it clears. I added a unit test in `create.test.js` that reproduces the back-button case (`hashchange`/`popstate` without `location-changed`) and checks the highlight is removed.

## Additional information

- This PR fixes or closes issue: fixes #2074

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.