### PR TITLE
Calendar card: don't render "undefined" when there are no events

### DIFF
--- a/src/cards/calendar/changes.js
+++ b/src/cards/calendar/changes.js
@@ -127,7 +127,7 @@ export async function changeEvents(context) {
         eventColor.style.display = 'none';
       }
 
-      if (context.config.show_place === true && event.location !== null) {
+      if (context.config.show_place === true && event.location) {
         const eventPlace = createElement('div', 'bubble-event-place');
         applyScrollingEffect(context, eventPlace, event.location);
         eventNameWrapper.appendChild(eventPlace);
@@ -138,16 +138,20 @@ export async function changeEvents(context) {
       eventLine.appendChild(eventTime);
       eventLine.appendChild(eventNameWrapper);
 
-      addActions(
-        eventLine, 
-        context.config.event_action,
-        event.entity.entity,
-        {
-          tap_action: { action: "none" },
-          double_tap_action: { action: "none" },
-          hold_action: { action: "none" }
-        }
-      );
+      // Only wire up actions for real events; the "No events" placeholder has
+      // no entity, so a configured more-info would fail with "Invalid entity_ids".
+      if (event.entity.entity) {
+        addActions(
+          eventLine,
+          context.config.event_action,
+          event.entity.entity,
+          {
+            tap_action: { action: "none" },
+            double_tap_action: { action: "none" },
+            hold_action: { action: "none" }
+          }
+        );
+      }
 
       const activeColor = 'var(--bubble-event-accent-color, var(--bubble-accent-color, var(--bubble-default-color)))';
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->

When a calendar has no upcoming events the card renders a "No events" placeholder. That placeholder has no location, but the old check was `event.location !== null`, so an `undefined` location still passed it and the card showed the literal text "undefined". Switched it to a truthy check so the place line is skipped when there's nothing to show.

While I was there I also wrapped the action wiring in an `if (event.entity.entity)` so we only attach tap/hold actions to real events. The placeholder has no entity, and a configured more-info would otherwise fail with "Invalid entity_ids".

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: custom:bubble-card
card_type: calendar
show_place: true
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2504
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

<!--
  Thank you for contributing <3
-->