### PR TITLE
fix: keep mobile pop-ups below the status bar on the edge-to-edge companion app

### DIFF
--- a/src/cards/pop-up/styles.css
+++ b/src/cards/pop-up/styles.css
@@ -182,10 +182,12 @@
     content: none;
 }
 
+/* The edge-to-edge companion app leaves the top safe-area inset to the page */
 .bubble-pop-up:not(.editor) {
-    --bubble-pop-up-available-height: calc(100vh - 56px - var(--custom-height-offset-mobile));
+    --bubble-pop-up-safe-area-top: var(--safe-area-inset-top, 0px);
+    --bubble-pop-up-available-height: calc(100vh - 56px - var(--bubble-pop-up-safe-area-top) - var(--custom-height-offset-mobile));
     height: auto;
-    top: calc(56px + var(--custom-height-offset-mobile));
+    top: calc(56px + var(--bubble-pop-up-safe-area-top) + var(--custom-height-offset-mobile));
     bottom: 0;
 }
 
@@ -300,7 +302,7 @@
 .bubble-pop-up:not(.editor):not(.is-standalone-pop-up):not(.popup-mode-fit-content):not(.popup-mode-centered):not(.popup-mode-adaptive-dialog) {
     height: 100%;
     top: auto;
-    bottom: calc(-56px - var(--custom-height-offset-mobile));
+    bottom: calc(-56px - var(--bubble-pop-up-safe-area-top) - var(--custom-height-offset-mobile));
 }
 
 .bubble-pop-up.is-standalone-pop-up:not(.popup-mode-fit-content):not(.popup-mode-centered):not(.popup-mode-adaptive-dialog):not(.editor) {
@@ -320,7 +322,7 @@
     height: 100%;
     margin-top: -50px;
     padding-top: 18px;
-    padding-bottom: calc(140px + var(--custom-height-offset-mobile));
+    padding-bottom: calc(140px + var(--bubble-pop-up-safe-area-top) + var(--custom-height-offset-mobile));
     mask-image: linear-gradient(to bottom, transparent 0px, black 24px, black calc(100% - 40px), transparent 100%);
     -webkit-mask-image: linear-gradient(to bottom, transparent 0px, black 24px, black calc(100% - 40px), transparent 100%);
     touch-action: pan-y pinch-zoom;

--- a/src/cards/pop-up/styles.test.js
+++ b/src/cards/pop-up/styles.test.js
@@ -118,6 +118,19 @@ describe('pop-up styles', () => {
     expect(styles).not.toMatch(/^\s*\.bubble-pop-up\.popup-mode-centered[^,{]*> \.bubble-pop-up-container::after/m);
   });
 
+  // The companion app is edge-to-edge on phones since HA 2026.8 and leaves the
+  // top safe-area inset to the page. A fixed pop-up must add it back or it
+  // climbs into the status bar by that inset. HA publishes the inset as
+  // --safe-area-inset-top (the app sets --app-safe-area-inset-top behind it),
+  // so read that token rather than env() directly.
+  test('keeps mobile pop-ups below the top safe-area inset', () => {
+    expect(styles).toContain('--bubble-pop-up-safe-area-top: var(--safe-area-inset-top, 0px);');
+    expect(styles).toMatch(/\.bubble-pop-up:not\(\.editor\) \{[^}]*top: calc\(56px \+ var\(--bubble-pop-up-safe-area-top\) \+ var\(--custom-height-offset-mobile\)\);/);
+    expect(styles).toMatch(/--bubble-pop-up-available-height: calc\(100vh - 56px - var\(--bubble-pop-up-safe-area-top\) - var\(--custom-height-offset-mobile\)\);/);
+    expect(styles).toMatch(/bottom: calc\(-56px - var\(--bubble-pop-up-safe-area-top\) - var\(--custom-height-offset-mobile\)\);/);
+    expect(styles).toMatch(/padding-bottom: calc\(140px \+ var\(--bubble-pop-up-safe-area-top\) \+ var\(--custom-height-offset-mobile\)\);/);
+  });
+
   // #2537: pop-ups are position:fixed, so they offset themselves to stay
   // centred on the dashboard rather than on the viewport. That offset used to
   // be read from var(--ha-sidebar-width, var(--mdc-drawer-width, 0px)): width


### PR DESCRIPTION
## Proposed change

Since Home Assistant 2026.8 the iOS companion app draws edge-to-edge on phones (home-assistant/iOS PR #5142). The webview now starts at the very top of the screen and the frontend is expected to apply `env(safe-area-inset-top)` itself. The gate is the core version, so this reaches everyone on core 2026.8 or newer with a current app.

Pop-ups are `position: fixed` with a hard-coded `top: 56px` on mobile. That value assumed the viewport already started below the status bar. On an edge-to-edge webview the pop-up moves up by the inset (about 60px on current iPhones) and grows taller by the same amount. Users see pop-ups that suddenly fill more of the screen after the core update, sitting flush under the status bar and covering the top row of the dashboard behind them.

### Fix

Add `env(safe-area-inset-top, 0px)` to the mobile top offset, to `--bubble-pop-up-available-height`, and to the two bottom values that mirror the offset. The inset is exposed as `--bubble-pop-up-safe-area-top` so themes can override it.

The inset is 0 on desktop, in mobile browsers that already inset the viewport, and in older companion apps, so nothing changes there. It is also correct when the HA header is visible, because that header now grows by the same inset.

`margin_top_mobile` keeps working as before and is added on top of the inset.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration

Any pop-up reproduces it. Open it in the iOS companion app 2026.8 or newer against core 2026.8 or newer, with or without the HA header hidden.

```yaml
type: custom:bubble-card
card_type: pop-up
hash: '#guest-office'
name: Guest Office
icon: mdi:laptop
```

## Example printscreens/gif

iPhone 17 Pro, iOS 26.6.1, companion app 2026.9.0, core 2026.8.3, Bubble Card 3.3.0. The dashboard has the HA header hidden, so the power chips row is the first thing on the page.

| Before (v3.3.0) | After (this PR) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/finder39/Bubble-Card/assets/popup-safe-area/before.png) | ![after](https://raw.githubusercontent.com/finder39/Bubble-Card/assets/popup-safe-area/after.png) |

Before, the pop-up starts right under the status bar and hides the chips row. After, it starts one header height below the status bar, where it was before core 2026.8.

## Additional information

- This PR fixes or closes issue: none filed, happy to open one if you prefer
- This PR is related to issue or discussion: home-assistant/iOS#5586 (closed on the app side as intended behavior, the page is expected to handle the inset)
- Link to documentation pull request: none needed

## Additional documentation needed.

None. No configuration changes, existing `margin_top_mobile` values keep their meaning.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests screenshots/gifs have been added to verify that the new code works.

Full jest suite passes (69 suites, 1131 tests) with one new assertion in `styles.test.js`. `dist/bubble-card.js` is rebuilt with `npm run dist`.
