### PR TITLE
Clear media player background when switching to a track without album art

### DIFF
--- a/src/cards/media-player/changes.js
+++ b/src/cards/media-player/changes.js
@@ -256,37 +256,45 @@ function getMediaCoverState(context) {
             iconDisplayedUrl: '',
             backgroundDisplayedUrl: '',
             idleTimeout: null,
-            lastState: ''
+            lastState: '',
+            lastFingerprint: ''
         };
     }
     return context._mediaCoverState;
 }
 
-function evaluateCoverState(context) {
+export function evaluateCoverState(context) {
     const coverState = getMediaCoverState(context);
     const forceIcon = Boolean(context.config.force_icon);
     let rawCover = forceIcon ? '' : (getImage(context) || '');
     const entityState = (getState(context) || '').toLowerCase();
 
-    // Append a media content fingerprint as a cache-busting parameter to handle
-    // proxy URLs that stay identical across different media (e.g., Apple TV).
-    // Same content produces the same hash, avoiding unnecessary re-fetches.
-    if (rawCover) {
-        const fp = (getAttribute(context, "media_content_id") || '')
-            + (getAttribute(context, "media_title") || '')
-            + (getAttribute(context, "media_artist") || '');
-        if (fp) {
-            let h = 0;
-            for (let i = 0; i < fp.length; i++) {
-                h = ((h << 5) - h) + fp.charCodeAt(i);
-                h |= 0;
-            }
-            const sep = rawCover.includes('?') ? '&' : '?';
-            rawCover = `${rawCover}${sep}v=${Math.abs(h).toString(36)}`;
+    // Media content fingerprint identifying the currently playing media. Used both
+    // as a cache-busting parameter (proxy URLs may stay identical across different
+    // media, e.g. Apple TV) and to detect a real track change.
+    const fingerprint = (getAttribute(context, "media_content_id") || '')
+        + (getAttribute(context, "media_title") || '')
+        + (getAttribute(context, "media_artist") || '');
+
+    // Append the fingerprint as a cache-busting parameter so the same content
+    // produces the same hash, avoiding unnecessary re-fetches.
+    if (rawCover && fingerprint) {
+        let h = 0;
+        for (let i = 0; i < fingerprint.length; i++) {
+            h = ((h << 5) - h) + fingerprint.charCodeAt(i);
+            h |= 0;
         }
+        const sep = rawCover.includes('?') ? '&' : '?';
+        rawCover = `${rawCover}${sep}v=${Math.abs(h).toString(36)}`;
     }
     const shouldReset = forceIcon || MEDIA_COVER_RESET_STATES.has(entityState);
     const isIdle = entityState === 'idle';
+
+    // A different track is now playing but it has no cover art: drop the cached
+    // cover so the previous album art doesn't linger in the background.
+    const mediaChangedWithoutCover = !rawCover && !isIdle
+        && fingerprint !== '' && fingerprint !== coverState.lastFingerprint;
+    coverState.lastFingerprint = fingerprint;
 
     if (coverState.lastState !== entityState) {
         if (coverState.idleTimeout) {
@@ -310,7 +318,7 @@ function evaluateCoverState(context) {
             coverState.idleTimeout = null;
         }
         coverState.cachedUrl = rawCover;
-    } else if (shouldReset && !rawCover && coverState.cachedUrl) {
+    } else if ((shouldReset || mediaChangedWithoutCover) && !rawCover && coverState.cachedUrl) {
         if (coverState.idleTimeout) {
             clearTimeout(coverState.idleTimeout);
             coverState.idleTimeout = null;

--- a/src/cards/media-player/changes.test.js
+++ b/src/cards/media-player/changes.test.js
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+
+// Cut the CSS import chains so the module loads under the node test environment
+// (utils.js -> base-card/index.js -> *.css, and style-processor.js -> sub-button -> *.css).
+jest.unstable_mockModule('../../components/base-card/index.js', () => ({
+    updateContentContainerFixedClass: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../tools/style-processor.js', () => ({
+    handleCustomStyles: jest.fn(),
+}));
+
+const ENTITY = 'media_player.test';
+let evaluateCoverState;
+
+beforeAll(async () => {
+    ({ evaluateCoverState } = await import('./changes.js'));
+});
+
+// Minimal context whose hass state can be mutated between calls so the
+// per-context cover state (context._mediaCoverState) persists, mirroring how
+// the card re-evaluates on every hass update.
+function makeContext() {
+    return {
+        config: { entity: ENTITY, cover_background: true },
+        _hass: {
+            hassUrl: (path) => path,
+            states: {
+                [ENTITY]: { state: 'idle', attributes: {} }
+            }
+        }
+    };
+}
+
+function setTrack(context, { state = 'playing', entity_picture, media_content_id, media_title, media_artist }) {
+    const attributes = {};
+    if (entity_picture) attributes.entity_picture = entity_picture;
+    if (media_content_id) attributes.media_content_id = media_content_id;
+    if (media_title) attributes.media_title = media_title;
+    if (media_artist) attributes.media_artist = media_artist;
+    context._hass.states[ENTITY] = { state, attributes };
+}
+
+describe('evaluateCoverState', () => {
+    test('removes the cached cover when switching to a track without album art', () => {
+        const context = makeContext();
+
+        // Track 1 has album art.
+        setTrack(context, {
+            entity_picture: '/art/track1.png',
+            media_content_id: '1',
+            media_title: 'Aloe Blacc',
+            media_artist: 'Aloe Blacc'
+        });
+        expect(evaluateCoverState(context).resolvedUrl).toContain('/art/track1.png');
+
+        // Track 2 (different album) has no album art -> background must be cleared.
+        setTrack(context, {
+            media_content_id: '2',
+            media_title: 'Madama Butterfly',
+            media_artist: 'Puccini'
+        });
+        expect(evaluateCoverState(context).resolvedUrl).toBe('');
+    });
+
+    test('keeps the cover during a transient empty cover for the same track', () => {
+        const context = makeContext();
+
+        setTrack(context, {
+            entity_picture: '/art/track1.png',
+            media_content_id: '1',
+            media_title: 'Aloe Blacc',
+            media_artist: 'Aloe Blacc'
+        });
+        const url = evaluateCoverState(context).resolvedUrl;
+        expect(url).toContain('/art/track1.png');
+
+        // Same track, cover momentarily missing -> previous cover should remain.
+        setTrack(context, {
+            media_content_id: '1',
+            media_title: 'Aloe Blacc',
+            media_artist: 'Aloe Blacc'
+        });
+        expect(evaluateCoverState(context).resolvedUrl).toBe(url);
+    });
+});


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
When the media player moves to a new track that has no album art, the old cover stayed in the background. The cover only got reset on idle/off states, not on a plain track change while still playing.

I now keep a small fingerprint of the playing media (content_id + title + artist) on the cover state. When that fingerprint changes and the new track has no cover, the cached background is dropped. A momentarily empty cover for the same track is left alone, so we don't flicker the background on a transient miss.

## Type of change
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example configuration
<!--
  Supplying a configuration snippet of the thing you are changing , makes it easier for a maintainer to test
  your PR.
-->

```yaml
type: custom:bubble-card
card_type: media-player
entity: media_player.living_room
```

## Example printscreens/gif
<!--
  Add a printscreen from the feature/bug/breaking change before and after your PR.
-->
Before: playing a track with art, then switching to one without art keeps the previous album art in the background.
After: switching to a track without art clears the background.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #2457
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Additional documentation needed.
<!--
  If you made a new feature, enhancement, breaking change please provide some clear 
  explanation for the end-user how to use this. 
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [ ] Tests screenshots/gifs have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for readme.

I also added a Jest test in `src/cards/media-player/changes.test.js` covering the track-change-without-art case (fails without this fix) plus the transient-empty-cover case; `npm test` is green locally (229 tests).

<!--
  Thank you for contributing <3
-->